### PR TITLE
[feat] Add GPU Direct RDMA (GDR) support for MooncakeStore backend.

### DIFF
--- a/scripts/performance_test/breakdown_test.py
+++ b/scripts/performance_test/breakdown_test.py
@@ -1,0 +1,935 @@
+#!/usr/bin/env python3
+# Copyright 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2025 The TransferQueue Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+MooncakeStore PUT/GET latency breakdown test.
+
+Captures all [TQ-TIMING] print lines from every layer of the stack:
+  interface.py   → kv_batch_put / kv_batch_get
+  client.py      → client::put  / client::get_data
+  base.py        → storage_mgr::get_data
+  mooncake_client.py → mooncake::batch_put_tensor / mooncake::batch_get_tensor  (×N batches)
+
+See CALLSTACK.md for the full call graph and measurement-point descriptions.
+
+Breakdown available from Python:
+  PUT: retrieve_meta | mooncake_batch_put (RDMA) | set_custom_meta
+  GET: retrieve_meta | mooncake_batch_get (BatchQuery+RDMA, unsplit) | merge_to_tensordict
+  Note: BatchQuery vs. RDMA split inside each batch_get_tensor requires C++ instrumentation.
+
+Usage:
+  python breakdown_test.py \\
+    --backend_config perftest_config.yaml \\
+    --head_node_ip 10.x.x.1 \\
+    --worker_node_ip 10.x.x.2 \\
+    [--device cpu] [--num_warmup 1] [--num_iters 3] \\
+    [--scales small medium] [--output_dir ./results]
+"""
+
+import argparse
+import csv
+import io
+import logging
+import math
+import os
+import re
+import sys
+import time
+from contextlib import redirect_stdout
+from typing import Any
+
+import ray
+import torch
+from omegaconf import OmegaConf
+from tensordict import TensorDict
+
+import transfer_queue as tq
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE_LIMIT = 500  # must match mooncake_client.py
+
+# ── Scale definitions ──────────────────────────────────────────────────────────
+# (label, batch_size, field_num, seq_len)
+# Matches the "Small" / "Medium" settings in run_perf_test.sh
+SCALE_PRESETS = {
+    "small":  (1024,  9,  8192),
+    "medium": (4096, 15, 32768),
+    "large":  (8192, 18, 100000),
+}
+
+
+def data_size_gb(batch_size: int, field_num: int, seq_len: int) -> float:
+    return batch_size * field_num * seq_len * 4 / 1024**3  # float32
+
+
+def batchquery_calls(batch_size: int, field_num: int) -> int:
+    return math.ceil(batch_size * field_num / BATCH_SIZE_LIMIT)
+
+
+# ── [TQ-TIMING] log parser ─────────────────────────────────────────────────────
+#
+# Each captured stdout from an operation contains lines like:
+#   [TQ-TIMING] kv_batch_put n=1024: retrieve_meta=0.0052s  storage_put=0.2358s  total=0.2410s
+#   [TQ-TIMING] client::put n=1024: storage_put=0.2341s  set_custom_meta=0.0017s
+#   [TQ-TIMING] storage_mgr::put_data n=1024 fields=9: key_val_gen=0.0012s  storage_put=0.2341s  meta_processing=0.0005s  notify=0.0010s
+#   [TQ-TIMING] mooncake::batch_put_tensor n=500 data=0.0143GB  rdma=0.0245s  bw=4.66Gb/s
+#   [TQ-TIMING] mooncake::put_loop n=9216 batches=19: rdma_total=0.0841s  py_overhead=0.0196s  loop_total=0.1037s
+#   ... (one mooncake line per batch of BATCH_SIZE_LIMIT keys)
+#
+# For GET:
+#   [TQ-TIMING] kv_batch_get n=1024: retrieve_meta=0.0048s  storage_get=1.5237s  total=1.5285s
+#   [TQ-TIMING] client::get_data n=1024: storage_get=1.5237s
+#   [TQ-TIMING] storage_mgr::get_data n=1024 fields=9: key_gen=0.0030s  rdma_get=1.5203s  merge_to_tensordict=0.0034s
+#   [TQ-TIMING] mooncake::batch_get_tensor n=500 data=0.0143GB  rdma=0.0801s  bw=1.43Gb/s
+#   [TQ-TIMING] mooncake::get_loop n=9216 batches=19: rdma_total=1.0000s  py_overhead=0.0580s  loop_total=1.0580s
+#   ... (one mooncake line per batch of BATCH_SIZE_LIMIT keys)
+
+_KV_FLOAT = r"([\d.]+)s"
+
+
+def _f(name: str) -> str:
+    """Regex fragment: key=value"""
+    return rf"{name}={_KV_FLOAT}"
+
+
+def parse_put_timings(captured: str) -> dict[str, float]:
+    """Extract per-layer PUT timings from captured [TQ-TIMING] stdout."""
+    result: dict[str, float] = {}
+
+    # kv_batch_put line
+    m = re.search(
+        r"\[TQ-TIMING\] kv_batch_put[^:]*: " + _f("retrieve_meta") + r"\s+" + _f("storage_put") + r"\s+" + _f("total"),
+        captured,
+    )
+    if m:
+        result["kv_batch_put.retrieve_meta_s"] = float(m.group(1))
+        result["kv_batch_put.storage_put_s"]   = float(m.group(2))
+        result["kv_batch_put.total_s"]          = float(m.group(3))
+
+    # client::put line
+    m = re.search(
+        r"\[TQ-TIMING\] client::put[^:]*: " + _f("storage_put") + r"\s+" + _f("set_custom_meta"),
+        captured,
+    )
+    if m:
+        result["client.put.storage_put_s"]      = float(m.group(1))
+        result["client.put.set_custom_meta_s"]  = float(m.group(2))
+
+    # storage_mgr::put_data line (NEW)
+    m = re.search(
+        r"\[TQ-TIMING\] storage_mgr::put_data[^:]*: "
+        + _f("key_val_gen") + r"\s+" + _f("storage_put") + r"\s+"
+        + _f("meta_processing") + r"\s+" + _f("notify"),
+        captured,
+    )
+    if m:
+        result["storage_mgr.put.key_val_gen_s"]      = float(m.group(1))
+        result["storage_mgr.put.storage_put_s"]       = float(m.group(2))
+        result["storage_mgr.put.meta_processing_s"]   = float(m.group(3))
+        result["storage_mgr.put.notify_s"]            = float(m.group(4))
+
+    # mooncake::batch_put_tensor lines (sum over all batches)
+    mc_rdma_values = [float(v) for v in re.findall(
+        r"\[TQ-TIMING\] mooncake::batch_put_tensor[^\n]*rdma=" + _KV_FLOAT,
+        captured,
+    )]
+    result["mooncake.batch_put_tensor.count"]    = len(mc_rdma_values)
+    result["mooncake.batch_put_tensor.total_s"]  = sum(mc_rdma_values)
+    result["mooncake.batch_put_tensor.avg_s"]    = (
+        sum(mc_rdma_values) / len(mc_rdma_values) if mc_rdma_values else 0.0
+    )
+
+    # mooncake::put_loop summary line
+    m = re.search(
+        r"\[TQ-TIMING\] mooncake::put_loop[^:]*: "
+        + _f("rdma_total") + r"\s+" + _f("py_overhead") + r"\s+" + _f("loop_total"),
+        captured,
+    )
+    if m:
+        result["mooncake.put_loop.rdma_total_s"]  = float(m.group(1))
+        result["mooncake.put_loop.py_overhead_s"]  = float(m.group(2))
+        result["mooncake.put_loop.loop_total_s"]   = float(m.group(3))
+
+    # mooncake::gdr_batch_put lines (GDR path — staging buffer)
+    mc_gdr_d2d = [float(v) for v in re.findall(
+        r"\[TQ-TIMING\] mooncake::gdr_batch_put[^\n]*d2d=" + _KV_FLOAT, captured)]
+    mc_gdr_rdma = [float(v) for v in re.findall(
+        r"\[TQ-TIMING\] mooncake::gdr_batch_put[^\n]*rdma=" + _KV_FLOAT, captured)]
+    result["mooncake.gdr_batch_put.count"]      = len(mc_gdr_d2d)
+    result["mooncake.gdr_batch_put.d2d_total_s"] = sum(mc_gdr_d2d)
+    result["mooncake.gdr_batch_put.rdma_total_s"] = sum(mc_gdr_rdma)
+
+    # mooncake::gdr_put_loop summary
+    m = re.search(
+        r"\[TQ-TIMING\] mooncake::gdr_put_loop[^:]*: "
+        + _f("rdma_total") + r"\s+" + _f("d2d_total") + r"\s+" + _f("loop_total"),
+        captured,
+    )
+    if m:
+        result["mooncake.gdr_put_loop.rdma_total_s"] = float(m.group(1))
+        result["mooncake.gdr_put_loop.d2d_total_s"]  = float(m.group(2))
+        result["mooncake.gdr_put_loop.loop_total_s"]  = float(m.group(3))
+
+    # mooncake::put (top-level client put with classify overhead)
+    m = re.search(
+        r"\[TQ-TIMING\] mooncake::put n=[^:]*: "
+        + _f("classify") + r"\s+" + _f("total"),
+        captured,
+    )
+    if m:
+        result["mooncake.put.classify_s"] = float(m.group(1))
+        result["mooncake.put.total_s"]    = float(m.group(2))
+
+    return result
+
+
+def parse_get_timings(captured: str) -> dict[str, float]:
+    """Extract per-layer GET timings from captured [TQ-TIMING] stdout."""
+    result: dict[str, float] = {}
+
+    # kv_batch_get line
+    m = re.search(
+        r"\[TQ-TIMING\] kv_batch_get[^:]*: " + _f("retrieve_meta") + r"\s+" + _f("storage_get") + r"\s+" + _f("total"),
+        captured,
+    )
+    if m:
+        result["kv_batch_get.retrieve_meta_s"] = float(m.group(1))
+        result["kv_batch_get.storage_get_s"]   = float(m.group(2))
+        result["kv_batch_get.total_s"]          = float(m.group(3))
+
+    # client::get_data line
+    m = re.search(
+        r"\[TQ-TIMING\] client::get_data[^:]*: " + _f("storage_get"),
+        captured,
+    )
+    if m:
+        result["client.get_data.storage_get_s"] = float(m.group(1))
+
+    # storage_mgr::get_data line (UPDATED: now includes key_gen)
+    m = re.search(
+        r"\[TQ-TIMING\] storage_mgr::get_data[^:]*: "
+        + _f("key_gen") + r"\s+" + _f("rdma_get") + r"\s+" + _f("merge_to_tensordict"),
+        captured,
+    )
+    if m:
+        result["storage_mgr.key_gen_s"]               = float(m.group(1))
+        result["storage_mgr.rdma_get_s"]               = float(m.group(2))
+        result["storage_mgr.merge_to_tensordict_s"]    = float(m.group(3))
+    else:
+        # Fallback: old format without key_gen
+        m = re.search(
+            r"\[TQ-TIMING\] storage_mgr::get_data[^:]*: " + _f("rdma_get") + r"\s+" + _f("merge_to_tensordict"),
+            captured,
+        )
+        if m:
+            result["storage_mgr.key_gen_s"]               = 0.0
+            result["storage_mgr.rdma_get_s"]               = float(m.group(1))
+            result["storage_mgr.merge_to_tensordict_s"]    = float(m.group(2))
+
+    # mooncake::batch_get_tensor lines (sum over all batches)
+    # NOTE: each batch's rdma= includes BOTH BatchQuery (gRPC) + RDMA read.
+    # The split requires C++ instrumentation (see CALLSTACK.md).
+    mc_rdma_values = [float(v) for v in re.findall(
+        r"\[TQ-TIMING\] mooncake::batch_get_tensor[^\n]*rdma=" + _KV_FLOAT,
+        captured,
+    )]
+    result["mooncake.batch_get_tensor.count"]    = len(mc_rdma_values)
+    result["mooncake.batch_get_tensor.total_s"]  = sum(mc_rdma_values)
+    result["mooncake.batch_get_tensor.avg_s"]    = (
+        sum(mc_rdma_values) / len(mc_rdma_values) if mc_rdma_values else 0.0
+    )
+
+    # mooncake::get_loop summary line
+    m = re.search(
+        r"\[TQ-TIMING\] mooncake::get_loop[^:]*: "
+        + _f("rdma_total") + r"\s+" + _f("py_overhead") + r"\s+" + _f("loop_total"),
+        captured,
+    )
+    if m:
+        result["mooncake.get_loop.rdma_total_s"]  = float(m.group(1))
+        result["mooncake.get_loop.py_overhead_s"]  = float(m.group(2))
+        result["mooncake.get_loop.loop_total_s"]   = float(m.group(3))
+
+    # mooncake::gdr_batch_get lines (GDR path — staging buffer)
+    mc_gdr_rdma = [float(v) for v in re.findall(
+        r"\[TQ-TIMING\] mooncake::gdr_batch_get[^\n]*rdma=" + _KV_FLOAT, captured)]
+    mc_gdr_d2d = [float(v) for v in re.findall(
+        r"\[TQ-TIMING\] mooncake::gdr_batch_get[^\n]*d2d=" + _KV_FLOAT, captured)]
+    result["mooncake.gdr_batch_get.count"]       = len(mc_gdr_rdma)
+    result["mooncake.gdr_batch_get.rdma_total_s"] = sum(mc_gdr_rdma)
+    result["mooncake.gdr_batch_get.d2d_total_s"]  = sum(mc_gdr_d2d)
+
+    # mooncake::gdr_get_loop summary
+    m = re.search(
+        r"\[TQ-TIMING\] mooncake::gdr_get_loop[^:]*: "
+        + _f("rdma_total") + r"\s+" + _f("d2d_total") + r"\s+" + _f("loop_total"),
+        captured,
+    )
+    if m:
+        result["mooncake.gdr_get_loop.rdma_total_s"] = float(m.group(1))
+        result["mooncake.gdr_get_loop.d2d_total_s"]  = float(m.group(2))
+        result["mooncake.gdr_get_loop.loop_total_s"]  = float(m.group(3))
+
+    # mooncake::get (top-level client get with classify/scatter/gather)
+    m = re.search(
+        r"\[TQ-TIMING\] mooncake::get n=[^:]*: "
+        + _f("classify") + r"\s+" + _f("scatter") + r"\s+"
+        + _f("gather") + r"\s+" + _f("total"),
+        captured,
+    )
+    if m:
+        result["mooncake.get.classify_s"] = float(m.group(1))
+        result["mooncake.get.scatter_s"]  = float(m.group(2))
+        result["mooncake.get.gather_s"]   = float(m.group(3))
+        result["mooncake.get.total_s"]    = float(m.group(4))
+
+    return result
+
+
+# ── Ray actor ─────────────────────────────────────────────────────────────────
+
+@ray.remote
+class BreakdownActor:
+    """Ray actor that runs TQ PUT/GET and captures all [TQ-TIMING] stdout lines."""
+
+    def __init__(self, config: dict[str, Any]):
+        self.config = config
+        self.test_keys: list[str] = []
+        self.test_data: TensorDict | None = None
+
+    def initialize(self) -> None:
+        tq.init(OmegaConf.create(self.config))
+
+    def prepare_data(self, batch_size: int, field_num: int, seq_len: int, device: str = "cpu") -> float:
+        self.test_keys = [f"sample_{i}" for i in range(batch_size)]
+        td = TensorDict(batch_size=(batch_size,))
+        for f in range(field_num):
+            t = torch.randn(batch_size, seq_len, dtype=torch.float32)
+            if device == "gpu":
+                t = t.cuda()
+            td.set(f"field_{f}", t)
+        self.test_data = td
+        return data_size_gb(batch_size, field_num, seq_len)
+
+    def put_timed(self, partition_id: str) -> tuple[float, str]:
+        """
+        Run kv_batch_put. Returns (wall_clock_s, captured_tq_timing_stdout).
+
+        Captures all [TQ-TIMING] prints from:
+          interface.py  → kv_batch_put
+          client.py     → client::put
+          mooncake_client.py → mooncake::batch_put_tensor (×N batches)
+        """
+        buf = io.StringIO()
+        t0 = time.perf_counter()
+        with redirect_stdout(buf):
+            tq.kv_batch_put(keys=self.test_keys, partition_id=partition_id, fields=self.test_data)
+        wall = time.perf_counter() - t0
+        return wall, buf.getvalue()
+
+    def list_keys(self, partition_id: str) -> list[str]:
+        info = tq.kv_list(partition_id=partition_id)
+        return list(info.get(partition_id, {}).keys())
+
+    def get_timed(self, partition_id: str, keys: list[str]) -> tuple[float, str]:
+        """
+        Run kv_batch_get. Returns (wall_clock_s, captured_tq_timing_stdout).
+
+        Captures all [TQ-TIMING] prints from:
+          interface.py  → kv_batch_get
+          client.py     → client::get_data
+          base.py       → storage_mgr::get_data
+          mooncake_client.py → mooncake::batch_get_tensor (×N batches)
+        """
+        buf = io.StringIO()
+        t0 = time.perf_counter()
+        with redirect_stdout(buf):
+            tq.kv_batch_get(keys=keys, partition_id=partition_id)
+        wall = time.perf_counter() - t0
+        return wall, buf.getvalue()
+
+    def delete(self, partition_id: str, keys: list[str]) -> None:
+        tq.kv_clear(keys=keys, partition_id=partition_id)
+
+    def close(self) -> None:
+        tq.close()
+
+
+# ── Config & actor setup ───────────────────────────────────────────────────────
+
+def prepare_config(
+    backend_config_path: str, head_node_ip: str, worker_node_ip: str | None
+) -> dict[str, Any]:
+    config = OmegaConf.load(backend_config_path)
+    assert str(config.backend.storage_backend) == "MooncakeStore", (
+        "breakdown_test.py is for MooncakeStore only (got "
+        f"{config.backend.storage_backend})"
+    )
+    if worker_node_ip is not None:
+        mc = config.backend.MooncakeStore
+        for field in ("metadata_server", "master_server_address"):
+            val = str(getattr(mc, field, "") or "")
+            for placeholder in ("localhost", "127.0.0.1"):
+                if val.startswith(placeholder):
+                    new_val = val.replace(placeholder, head_node_ip, 1)
+                    setattr(mc, field, new_val)
+                    logger.info(f"Inter-node: override {field}: {val} → {new_val}")
+    return OmegaConf.to_container(config, resolve=True)
+
+
+def create_actors(
+    config: dict[str, Any],
+    head_node_ip: str,
+    worker_node_ip: str | None,
+    device: str,
+) -> tuple[Any, Any]:
+    writer_node = head_node_ip
+    reader_node = worker_node_ip or head_node_ip
+
+    def _opts(node_ip: str) -> dict:
+        opts: dict[str, Any] = {
+            "num_cpus": 0.001,
+            "resources": {f"node:{node_ip}": 0.001},
+        }
+        if device == "gpu":
+            opts["num_gpus"] = 1
+        elif device == "npu":
+            opts["resources"]["NPU"] = 1
+        return opts
+
+    writer = BreakdownActor.options(**_opts(writer_node)).remote(config)
+    reader = BreakdownActor.options(**_opts(reader_node)).remote(config)
+    ray.get([writer.initialize.remote(), reader.initialize.remote()])
+    logger.info(f"Writer on {writer_node}, reader on {reader_node}")
+    return writer, reader
+
+
+# ── Single-iteration benchmark ─────────────────────────────────────────────────
+
+def run_iteration(
+    label: str,
+    batch_size: int,
+    field_num: int,
+    writer: Any,
+    reader: Any,
+) -> dict[str, Any]:
+    """Run one PUT+GET cycle; return flat timing dict."""
+    partition_id = f"bkd_{label}"
+
+    # PUT
+    put_wall, put_captured = ray.get(writer.put_timed.remote(partition_id))
+    time.sleep(1)
+
+    # LIST keys (reader needs actual key list)
+    keys = ray.get(reader.list_keys.remote(partition_id))
+
+    # GET
+    get_wall, get_captured = ray.get(reader.get_timed.remote(partition_id, keys))
+    time.sleep(1)
+
+    # DELETE
+    ray.get(writer.delete.remote(partition_id, keys))
+    time.sleep(1)
+
+    # Parse TQ-TIMING logs
+    put_t = parse_put_timings(put_captured)
+    get_t = parse_get_timings(get_captured)
+
+    return {
+        "scale":       label,
+        "batch_size":  batch_size,
+        "field_num":   field_num,
+        "data_gb":     data_size_gb(batch_size, field_num, SCALE_PRESETS[label][2]),
+        "bq_calls":    batchquery_calls(batch_size, field_num),
+        # Wall-clock from caller (ray.get overhead included)
+        "put_wall_s":  put_wall,
+        "get_wall_s":  get_wall,
+        # PUT breakdown from [TQ-TIMING] prints
+        **{f"put.{k}": v for k, v in put_t.items()},
+        # GET breakdown from [TQ-TIMING] prints
+        **{f"get.{k}": v for k, v in get_t.items()},
+        # Captured raw lines (for debugging)
+        "_put_raw": put_captured,
+        "_get_raw": get_captured,
+    }
+
+
+# ── Pretty-print summary ───────────────────────────────────────────────────────
+
+def print_breakdown(r: dict[str, Any], label: str) -> None:
+    s = label
+    gb    = r["data_gb"]
+    bq    = r["bq_calls"]
+
+    # PUT - interface level
+    p_rmeta   = r.get("put.kv_batch_put.retrieve_meta_s", 0) * 1e3
+    p_scmeta  = r.get("put.client.put.set_custom_meta_s",  0) * 1e3
+    p_total   = r.get("put.kv_batch_put.total_s",          0) * 1e3
+    p_bw      = gb * 8 / (p_total / 1e3) if p_total else 0
+    # PUT - storage_mgr level
+    p_kvgen   = r.get("put.storage_mgr.put.key_val_gen_s",    0) * 1e3
+    p_metaproc = r.get("put.storage_mgr.put.meta_processing_s", 0) * 1e3
+    p_notify  = r.get("put.storage_mgr.put.notify_s",          0) * 1e3
+    # PUT - mooncake client level
+    p_classify = r.get("put.mooncake.put.classify_s", 0) * 1e3
+    # PUT - detect GDR vs baseline path
+    is_gdr = r.get("put.mooncake.gdr_batch_put.count", 0) > 0
+    if is_gdr:
+        pm_count  = int(r.get("put.mooncake.gdr_batch_put.count", 0))
+        pm_d2d    = r.get("put.mooncake.gdr_put_loop.d2d_total_s",  0) * 1e3
+        pm_rdma   = r.get("put.mooncake.gdr_put_loop.rdma_total_s", 0) * 1e3
+        pm_loop   = r.get("put.mooncake.gdr_put_loop.loop_total_s", 0) * 1e3
+        pm_pyoh   = max(0, pm_loop - pm_d2d - pm_rdma)
+    else:
+        pm_count  = int(r.get("put.mooncake.batch_put_tensor.count", 0))
+        pm_d2d    = 0.0
+        pm_rdma   = r.get("put.mooncake.put_loop.rdma_total_s",  0) * 1e3
+        pm_pyoh   = r.get("put.mooncake.put_loop.py_overhead_s", 0) * 1e3
+        pm_loop   = r.get("put.mooncake.put_loop.loop_total_s",  0) * 1e3
+    # PUT - remaining gap
+    p_accounted = p_rmeta + p_kvgen + p_classify + pm_loop + p_metaproc + p_notify + p_scmeta
+    p_gap = max(0, p_total - p_accounted)
+
+    # GET - interface level
+    g_rmeta   = r.get("get.kv_batch_get.retrieve_meta_s", 0) * 1e3
+    g_total   = r.get("get.kv_batch_get.total_s",          0) * 1e3
+    g_bw      = gb * 8 / (g_total / 1e3) if g_total else 0
+    # GET - storage_mgr level
+    g_keygen  = r.get("get.storage_mgr.key_gen_s",              0) * 1e3
+    g_merge   = r.get("get.storage_mgr.merge_to_tensordict_s",  0) * 1e3
+    # GET - mooncake client level
+    g_classify = r.get("get.mooncake.get.classify_s", 0) * 1e3
+    g_scatter  = r.get("get.mooncake.get.scatter_s",  0) * 1e3
+    g_gather   = r.get("get.mooncake.get.gather_s",   0) * 1e3
+    # GET - detect GDR vs baseline path
+    is_gdr_get = r.get("get.mooncake.gdr_batch_get.count", 0) > 0
+    if is_gdr_get:
+        gm_count  = int(r.get("get.mooncake.gdr_batch_get.count", 0))
+        gm_d2d    = r.get("get.mooncake.gdr_get_loop.d2d_total_s",  0) * 1e3
+        gm_rdma   = r.get("get.mooncake.gdr_get_loop.rdma_total_s", 0) * 1e3
+        gm_loop   = r.get("get.mooncake.gdr_get_loop.loop_total_s", 0) * 1e3
+        gm_pyoh   = max(0, gm_loop - gm_d2d - gm_rdma)
+    else:
+        gm_count  = int(r.get("get.mooncake.batch_get_tensor.count", 0))
+        gm_d2d    = 0.0
+        gm_rdma   = r.get("get.mooncake.get_loop.rdma_total_s",  0) * 1e3
+        gm_pyoh   = r.get("get.mooncake.get_loop.py_overhead_s", 0) * 1e3
+        gm_loop   = r.get("get.mooncake.get_loop.loop_total_s",  0) * 1e3
+    # GET - remaining gap
+    g_accounted = g_rmeta + g_keygen + g_classify + g_scatter + gm_loop + g_gather + g_merge
+    g_gap = max(0, g_total - g_accounted)
+
+    mode_tag = " [GDR]" if is_gdr else " [Baseline]"
+    print(f"\n  ┌─ {s}{mode_tag}  ({gb:.3f} GB, {bq} BatchQuery calls/GET) {'─'*30}")
+    print(f"  │  PUT  total={p_total:7.1f}ms  bw={p_bw:6.1f} Gb/s")
+    print(f"  │    ├ retrieve_meta (ZMQ→controller)  : {p_rmeta:7.1f} ms")
+    print(f"  │    ├ key_val_gen (Python)             : {p_kvgen:7.1f} ms")
+    classify_desc = "classify (no D2H, GPU stays)" if is_gdr else "classify (D2H: .cuda()→.cpu())"
+    print(f"  │    ├ {classify_desc:<37}: {p_classify:7.1f} ms")
+    print(f"  │    ├ mooncake_loop ×{pm_count:<3}              : {pm_loop:7.1f} ms")
+    if is_gdr:
+        print(f"  │    │   ├ D2D copy (GPU→staging buf)  : {pm_d2d:7.1f} ms")
+        print(f"  │    │   ├ GDR RDMA transfer            : {pm_rdma:7.1f} ms")
+        print(f"  │    │   └ Python overhead              : {pm_pyoh:7.1f} ms")
+    else:
+        print(f"  │    │   ├ C++ batch_put_tensor         : {pm_rdma:7.1f} ms")
+        print(f"  │    │   └ Python overhead (slice+valid): {pm_pyoh:7.1f} ms")
+    print(f"  │    ├ meta_processing (Python)         : {p_metaproc:7.1f} ms")
+    print(f"  │    ├ notify (ZMQ→controller)          : {p_notify:7.1f} ms")
+    print(f"  │    ├ set_custom_meta (ZMQ→controller) : {p_scmeta:7.1f} ms")
+    if p_gap > 0.5:
+        print(f"  │    └ remaining gap                   : {p_gap:7.1f} ms")
+    print(f"  │")
+    print(f"  │  GET  total={g_total:7.1f}ms  bw={g_bw:6.1f} Gb/s")
+    print(f"  │    ├ retrieve_meta (ZMQ→controller)  : {g_rmeta:7.1f} ms")
+    print(f"  │    ├ key_gen (Python)                : {g_keygen:7.1f} ms")
+    print(f"  │    ├ classify+scatter (Python)       : {g_classify + g_scatter:7.1f} ms")
+    print(f"  │    ├ mooncake_loop ×{gm_count:<3}              : {gm_loop:7.1f} ms")
+    if is_gdr_get:
+        print(f"  │    │   ├ GDR RDMA transfer            : {gm_rdma:7.1f} ms")
+        print(f"  │    │   ├ D2D copy (staging buf→GPU)  : {gm_d2d:7.1f} ms")
+        print(f"  │    │   └ Python overhead              : {gm_pyoh:7.1f} ms")
+    else:
+        print(f"  │    │   ├ C++ batch_get_tensor         : {gm_rdma:7.1f} ms")
+        print(f"  │    │   └ Python overhead (slice+valid): {gm_pyoh:7.1f} ms")
+    print(f"  │    ├ gather (Python, result scatter)  : {g_gather:7.1f} ms")
+    print(f"  │    ├ merge_to_tensordict (CPU)        : {g_merge:7.1f} ms")
+    if g_gap > 0.5:
+        print(f"  │    └ remaining gap                   : {g_gap:7.1f} ms")
+    print(f"  └{'─'*60}")
+
+
+# ── CSV ────────────────────────────────────────────────────────────────────────
+
+def save_csv(results: list[dict[str, Any]], path: str) -> None:
+    # Exclude raw captured stdout from CSV (too large)
+    rows = [{k: v for k, v in r.items() if not k.startswith("_")} for r in results]
+    if not rows:
+        return
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+    logger.info(f"Results saved → {path}")
+
+
+def save_raw_log(results: list[dict[str, Any]], path: str) -> None:
+    with open(path, "w") as f:
+        for r in results:
+            f.write(f"=== scale={r['scale']} iter={r.get('iter','')} ===\n")
+            f.write("--- PUT captured stdout ---\n")
+            f.write(r.get("_put_raw", "") + "\n")
+            f.write("--- GET captured stdout ---\n")
+            f.write(r.get("_get_raw", "") + "\n")
+    logger.info(f"Raw [TQ-TIMING] log saved → {path}")
+
+
+# ── Chart ──────────────────────────────────────────────────────────────────────
+
+def draw_chart(results: list[dict[str, Any]], out_path: str) -> None:
+    """
+    Two-panel stacked bar chart with full breakdown including Python overhead.
+      Left panel:  PUT breakdown
+      Right panel: GET breakdown
+    Each bar's components sum to total; unmeasured gap shown as hatched red.
+    """
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        import numpy as np
+    except ImportError:
+        logger.warning("matplotlib not installed; skipping chart generation.")
+        return
+
+    from collections import defaultdict
+    import statistics
+
+    # Aggregate across iterations per scale
+    agg: dict[str, dict[str, list]] = defaultdict(lambda: defaultdict(list))
+    for r in results:
+        sc = r["scale"]
+        agg[sc]["data_gb"].append(r["data_gb"])
+        agg[sc]["bq_calls"].append(r["bq_calls"])
+
+        p_total = r.get("put.kv_batch_put.total_s", 0) * 1e3
+        p_rmeta = r.get("put.kv_batch_put.retrieve_meta_s", 0) * 1e3
+        p_kvgen = r.get("put.storage_mgr.put.key_val_gen_s", 0) * 1e3
+        p_classify = r.get("put.mooncake.put.classify_s", 0) * 1e3
+        # Detect GDR vs baseline for PUT
+        if r.get("put.mooncake.gdr_batch_put.count", 0) > 0:
+            p_d2d   = r.get("put.mooncake.gdr_put_loop.d2d_total_s", 0) * 1e3
+            p_rdma  = r.get("put.mooncake.gdr_put_loop.rdma_total_s", 0) * 1e3
+            p_loop  = r.get("put.mooncake.gdr_put_loop.loop_total_s", 0) * 1e3
+            p_pyoh  = max(0, p_loop - p_d2d - p_rdma)
+        else:
+            p_d2d   = 0.0
+            p_rdma  = r.get("put.mooncake.put_loop.rdma_total_s", 0) * 1e3
+            p_pyoh  = r.get("put.mooncake.put_loop.py_overhead_s", 0) * 1e3
+        p_metap = r.get("put.storage_mgr.put.meta_processing_s", 0) * 1e3
+        p_notify = r.get("put.storage_mgr.put.notify_s", 0) * 1e3
+        p_scm   = r.get("put.client.put.set_custom_meta_s", 0) * 1e3
+        p_gap   = max(0, p_total - p_rmeta - p_kvgen - p_classify - p_d2d - p_rdma - p_pyoh - p_metap - p_notify - p_scm)
+
+        agg[sc]["put.total"].append(p_total)
+        agg[sc]["put.retrieve_meta"].append(p_rmeta)
+        agg[sc]["put.key_val_gen"].append(p_kvgen)
+        agg[sc]["put.classify"].append(p_classify)
+        agg[sc]["put.d2d"].append(p_d2d)
+        agg[sc]["put.rdma"].append(p_rdma)
+        agg[sc]["put.loop_pyoh"].append(p_pyoh)
+        agg[sc]["put.meta_processing"].append(p_metap)
+        agg[sc]["put.notify"].append(p_notify)
+        agg[sc]["put.set_custom_meta"].append(p_scm)
+        agg[sc]["put.gap"].append(p_gap)
+
+        g_total = r.get("get.kv_batch_get.total_s", 0) * 1e3
+        g_rmeta = r.get("get.kv_batch_get.retrieve_meta_s", 0) * 1e3
+        g_keygen = r.get("get.storage_mgr.key_gen_s", 0) * 1e3
+        g_classify = r.get("get.mooncake.get.classify_s", 0) * 1e3
+        g_scatter = r.get("get.mooncake.get.scatter_s", 0) * 1e3
+        # Detect GDR vs baseline for GET
+        if r.get("get.mooncake.gdr_batch_get.count", 0) > 0:
+            g_d2d   = r.get("get.mooncake.gdr_get_loop.d2d_total_s", 0) * 1e3
+            g_rdma  = r.get("get.mooncake.gdr_get_loop.rdma_total_s", 0) * 1e3
+            g_loop  = r.get("get.mooncake.gdr_get_loop.loop_total_s", 0) * 1e3
+            g_pyoh  = max(0, g_loop - g_d2d - g_rdma)
+        else:
+            g_d2d   = 0.0
+            g_rdma  = r.get("get.mooncake.get_loop.rdma_total_s", 0) * 1e3
+            g_pyoh  = r.get("get.mooncake.get_loop.py_overhead_s", 0) * 1e3
+        g_gather = r.get("get.mooncake.get.gather_s", 0) * 1e3
+        g_merge = r.get("get.storage_mgr.merge_to_tensordict_s", 0) * 1e3
+        g_gap   = max(0, g_total - g_rmeta - g_keygen - g_classify - g_scatter - g_d2d - g_rdma - g_pyoh - g_gather - g_merge)
+
+        agg[sc]["get.total"].append(g_total)
+        agg[sc]["get.retrieve_meta"].append(g_rmeta)
+        agg[sc]["get.key_gen"].append(g_keygen)
+        agg[sc]["get.classify_scatter"].append(g_classify + g_scatter)
+        agg[sc]["get.d2d"].append(g_d2d)
+        agg[sc]["get.rdma"].append(g_rdma)
+        agg[sc]["get.loop_pyoh"].append(g_pyoh)
+        agg[sc]["get.gather"].append(g_gather)
+        agg[sc]["get.merge"].append(g_merge)
+        agg[sc]["get.gap"].append(g_gap)
+
+    scale_order = [s for s in ("small", "medium", "large") if s in agg]
+    n = len(scale_order)
+    if n == 0:
+        return
+
+    def mean(lst):
+        return statistics.mean(lst) if lst else 0.0
+
+    gb_arr = np.array([mean(agg[s]["data_gb"]) for s in scale_order])
+    bq_arr = [int(mean(agg[s]["bq_calls"])) for s in scale_order]
+
+    # PUT arrays
+    put_rmeta  = np.array([mean(agg[s]["put.retrieve_meta"]) for s in scale_order])
+    put_kvgen  = np.array([mean(agg[s]["put.key_val_gen"]) for s in scale_order])
+    put_classify = np.array([mean(agg[s]["put.classify"]) for s in scale_order])
+    put_d2d    = np.array([mean(agg[s]["put.d2d"]) for s in scale_order])
+    put_rdma   = np.array([mean(agg[s]["put.rdma"]) for s in scale_order])
+    put_pyoh   = np.array([mean(agg[s]["put.loop_pyoh"]) for s in scale_order])
+    put_metap  = np.array([mean(agg[s]["put.meta_processing"]) for s in scale_order])
+    put_notify = np.array([mean(agg[s]["put.notify"]) for s in scale_order])
+    put_scm    = np.array([mean(agg[s]["put.set_custom_meta"]) for s in scale_order])
+    put_gap    = np.array([mean(agg[s]["put.gap"]) for s in scale_order])
+    put_total  = np.array([mean(agg[s]["put.total"]) for s in scale_order])
+
+    # GET arrays
+    get_rmeta  = np.array([mean(agg[s]["get.retrieve_meta"]) for s in scale_order])
+    get_keygen = np.array([mean(agg[s]["get.key_gen"]) for s in scale_order])
+    get_d2d    = np.array([mean(agg[s]["get.d2d"]) for s in scale_order])
+    get_rdma   = np.array([mean(agg[s]["get.rdma"]) for s in scale_order])
+    get_pyoh   = np.array([mean(agg[s]["get.loop_pyoh"]) for s in scale_order])
+    get_merge  = np.array([mean(agg[s]["get.merge"]) for s in scale_order])
+    get_gap    = np.array([mean(agg[s]["get.gap"]) for s in scale_order])
+    get_total  = np.array([mean(agg[s]["get.total"]) for s in scale_order])
+
+    put_bw = gb_arr * 8 / (put_total / 1e3 + 1e-9)
+    get_bw = gb_arr * 8 / (get_total / 1e3 + 1e-9)
+
+    x = np.arange(n)
+    bw = 0.55
+
+    # Colors
+    c_zmq    = "#5B9BD5"   # blue   - ZMQ calls
+    c_keygen = "#A855F7"   # purple - key/value generation
+    c_class  = "#E97451"   # coral  - classify (includes D2H for baseline)
+    c_d2d    = "#17BECF"   # cyan   - D2D GPU copy (GDR only)
+    c_rdma_p = "#70AD47"   # green  - RDMA put
+    c_rdma_g = "#FF6B35"   # orange - RDMA get (gRPC+RDMA)
+    c_pyoh   = "#D9534F"   # red    - Python loop overhead
+    c_meta   = "#9DC3E6"   # light blue - meta processing
+    c_merge  = "#FFD966"   # yellow - merge_to_tensordict
+    c_gap    = "#888888"   # gray   - remaining gap
+
+    has_d2d = put_d2d.max() > 0 or get_d2d.max() > 0
+
+    fig, axes = plt.subplots(1, 2, figsize=(16, 7))
+
+    # ────── PUT panel ──────
+    ax = axes[0]
+    bottom = np.zeros(n)
+
+    def _bar(ax, vals, label, color, hatch=None):
+        nonlocal bottom
+        ax.bar(x, vals, bw, bottom=bottom, label=label, color=color,
+               zorder=3, edgecolor="white", linewidth=0.5, hatch=hatch)
+        bottom += vals
+
+    _bar(ax, put_rmeta,    "retrieve_meta (ZMQ)",                c_zmq)
+    _bar(ax, put_kvgen,    "key_val_gen (Python)",                c_keygen)
+    classify_label = "classify (no D2H)" if has_d2d else "classify (D2H: cuda→cpu)"
+    if put_classify.max() > 0.5:
+        _bar(ax, put_classify, classify_label,                    c_class)
+    if put_d2d.max() > 0:
+        _bar(ax, put_d2d,  "D2D copy (GPU→staging)",             c_d2d)
+    _bar(ax, put_rdma,     "RDMA transfer" if has_d2d else "C++ batch_put_tensor", c_rdma_p)
+    _bar(ax, put_pyoh,     "loop overhead (Python)",              c_pyoh, hatch="//")
+    _bar(ax, put_metap,    "meta_processing (Python)",            c_meta)
+    _bar(ax, put_notify,   "notify (ZMQ)",                        c_zmq)
+    _bar(ax, put_scm,      "set_custom_meta (ZMQ)",               c_zmq)
+    if put_gap.max() > 0.5:
+        _bar(ax, put_gap,  "remaining gap",                       c_gap, hatch="xx")
+
+    for i in range(n):
+        ax.text(i, put_total[i] + max(put_total) * 0.02,
+                f"{put_total[i]:.0f}ms\n{put_bw[i]:.1f} Gb/s",
+                ha="center", fontsize=9, fontweight="bold")
+
+    ax.set_title("PUT Breakdown", fontsize=13, fontweight="bold")
+    ax.set_ylabel("Time (ms)")
+    ax.set_xticks(x)
+    ax.set_xticklabels([f"{s}\n{gb_arr[i]:.2f} GB\n{bq_arr[i]} batches"
+                        for i, s in enumerate(scale_order)])
+    ax.grid(axis="y", alpha=0.3, zorder=0)
+    ax.legend(fontsize=7.5, loc="upper left")
+
+    # ────── GET panel ──────
+    ax = axes[1]
+    bottom = np.zeros(n)
+
+    _bar(ax, get_rmeta,  "retrieve_meta (ZMQ)",        c_zmq)
+    _bar(ax, get_keygen, "key_gen (Python)",            c_keygen)
+    _bar(ax, get_rdma,   "RDMA transfer" if has_d2d else "C++ batch_get_tensor", c_rdma_g)
+    if get_d2d.max() > 0:
+        _bar(ax, get_d2d, "D2D copy (staging→GPU)",    c_d2d)
+    _bar(ax, get_pyoh,   "loop overhead (Python)",      c_pyoh, hatch="//")
+    _bar(ax, get_merge,  "merge_to_tensordict (CPU)",   c_merge)
+    if get_gap.max() > 0.5:
+        _bar(ax, get_gap, "remaining gap",              c_gap, hatch="xx")
+
+    for i in range(n):
+        ax.text(i, get_total[i] + max(get_total) * 0.02,
+                f"{get_total[i]:.0f}ms\n{get_bw[i]:.1f} Gb/s",
+                ha="center", fontsize=9, fontweight="bold")
+
+    ax.set_title("GET Breakdown", fontsize=13, fontweight="bold")
+    ax.set_ylabel("Time (ms)")
+    ax.set_xticks(x)
+    ax.set_xticklabels([f"{s}\n{gb_arr[i]:.2f} GB\n{bq_arr[i]} batches"
+                        for i, s in enumerate(scale_order)])
+    ax.grid(axis="y", alpha=0.3, zorder=0)
+    ax.legend(fontsize=7.5, loc="upper left")
+
+    mode_label = "GDR (GPU Direct RDMA)" if has_d2d else "Baseline (CPU memcpy)"
+    fig.suptitle(
+        f"MooncakeStore Latency Breakdown — {mode_label}\n"
+        "Green/Orange = RDMA transfer  |  Cyan = D2D GPU copy  |  Red hatched = Python overhead",
+        fontsize=12, fontweight="bold",
+    )
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    logger.info(f"Chart saved → {out_path}")
+
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="MooncakeStore PUT/GET latency breakdown test",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--backend_config",  required=True,  help="Path to backend config YAML (must use MooncakeStore)")
+    parser.add_argument("--head_node_ip",    required=True,  help="Head node IP (mooncake_master host, writer node)")
+    parser.add_argument("--worker_node_ip",  default=None,   help="Reader node IP (omit for single-node test)")
+    parser.add_argument("--device",          default="cpu",  choices=["cpu", "gpu", "npu"])
+    parser.add_argument("--num_warmup",      type=int, default=1,  help="Warmup iterations per scale")
+    parser.add_argument("--num_iters",       type=int, default=3,  help="Measured iterations per scale")
+    parser.add_argument("--scales",          nargs="+", choices=list(SCALE_PRESETS), default=None,
+                        help="Which scales to test (default: all)")
+    parser.add_argument("--output_dir",      default="./results", help="Output directory for CSV and chart")
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    config = prepare_config(args.backend_config, args.head_node_ip, args.worker_node_ip)
+
+    ray.init(address="auto", ignore_reinit_error=True)
+    writer, reader = create_actors(config, args.head_node_ip, args.worker_node_ip, args.device)
+
+    scales_to_run = args.scales or list(SCALE_PRESETS.keys())
+    all_results: list[dict[str, Any]] = []
+
+    try:
+        for label in scales_to_run:
+            batch_size, field_num, seq_len = SCALE_PRESETS[label]
+            gb = data_size_gb(batch_size, field_num, seq_len)
+            bq = batchquery_calls(batch_size, field_num)
+
+            logger.info(f"\n{'='*65}")
+            logger.info(f"Scale: {label}  batch={batch_size}  fields={field_num}  seq={seq_len}")
+            logger.info(f"  data={gb:.3f} GB  total_keys={batch_size*field_num}  BatchQuery_calls/GET={bq}")
+
+            # Prepare test data on writer node
+            ray.get(writer.prepare_data.remote(batch_size, field_num, seq_len, args.device))
+
+            total_iters = args.num_warmup + args.num_iters
+            for i in range(total_iters):
+                is_warmup = i < args.num_warmup
+                tag = f"warmup-{i+1}" if is_warmup else f"iter-{i - args.num_warmup + 1}/{args.num_iters}"
+                logger.info(f"  [{label}] {tag}")
+
+                r = run_iteration(label, batch_size, field_num, writer, reader)
+                r["iter"] = -1 if is_warmup else (i - args.num_warmup + 1)
+
+                # Always print breakdown (useful for warmup too)
+                print_breakdown(r, f"{label} [{tag}]")
+
+                if not is_warmup:
+                    all_results.append(r)
+
+            time.sleep(5)
+
+    finally:
+        ray.get([writer.close.remote(), reader.close.remote()])
+
+    if not all_results:
+        logger.error("No measured results collected.")
+        sys.exit(1)
+
+    # ── Summary table ──
+    from collections import defaultdict
+    import statistics
+
+    agg: dict[str, dict[str, list]] = defaultdict(lambda: defaultdict(list))
+    for r in all_results:
+        sc = r["scale"]
+        for k in r:
+            if not k.startswith("_") and isinstance(r[k], float | int):
+                agg[sc][k].append(r[k])
+
+    print(f"\n{'='*95}")
+    print(f"{'Scale':<8} {'GB':>6} {'BQ':>5} | {'PUT ms':>8} {'PUT Gb/s':>9} | "
+          f"{'GET ms':>8} {'GET Gb/s':>9} | {'BQ overhead*':>13}")
+    print(f"{'-'*95}")
+    for sc in scales_to_run:
+        if sc not in agg:
+            continue
+        d = agg[sc]
+        put_ms = statistics.mean(d.get("put.kv_batch_put.total_s", [0])) * 1e3
+        get_ms = statistics.mean(d.get("get.kv_batch_get.total_s", [0])) * 1e3
+        gb_v   = statistics.mean(d.get("data_gb", [0]))
+        bq_v   = int(statistics.mean(d.get("bq_calls", [0])))
+        put_bw = gb_v * 8 / (put_ms / 1e3 + 1e-9)
+        get_bw = gb_v * 8 / (get_ms / 1e3 + 1e-9)
+        bq_est = get_ms - put_ms  # rough: all non-RDMA GET overhead
+        print(f"{sc:<8} {gb_v:>6.3f} {bq_v:>5} | "
+              f"{put_ms:>8.1f} {put_bw:>9.1f} | "
+              f"{get_ms:>8.1f} {get_bw:>9.1f} | "
+              f"{bq_est:>11.1f}ms")
+    print(f"{'='*95}")
+    print("* BQ overhead = GET_total - PUT_total (rough estimate; includes all non-RDMA GET latency)")
+    print("  True BatchQuery time needs C++ instrumentation in real_client.cpp (see CALLSTACK.md)")
+
+    # ── Save outputs ──
+    csv_path   = os.path.join(args.output_dir, "breakdown_results.csv")
+    log_path   = os.path.join(args.output_dir, "breakdown_raw_tqtiming.log")
+    chart_path = os.path.join(args.output_dir, "breakdown_chart.png")
+
+    save_csv(all_results, csv_path)
+    save_raw_log(all_results, log_path)
+    draw_chart(all_results, chart_path)
+
+    logger.info("Breakdown test complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/performance_test/mooncake_config.yaml
+++ b/scripts/performance_test/mooncake_config.yaml
@@ -1,0 +1,22 @@
+controller:
+  sampler: SequentialSampler
+  polling_mode: False
+  zmq_info: null
+
+backend:
+  storage_backend: MooncakeStore
+
+  MooncakeStore:
+    auto_init: true
+    metadata_server: localhost:50050
+    master_server_address: localhost:50051
+    local_hostname: ""
+    protocol: rdma
+    global_segment_size: 86294967296
+    local_buffer_size: 86294967296
+    device_name: ""
+    # GDR (GPU Direct RDMA): bypass CPU staging for GPU tensors
+    use_gdr: false
+    # Target GPU device for GDR GET path (null = use current CUDA device)
+    gdr_target_device: null
+    gdr_buffer_size: 1073741824

--- a/scripts/performance_test/mooncake_gdr_config.yaml
+++ b/scripts/performance_test/mooncake_gdr_config.yaml
@@ -1,0 +1,21 @@
+controller:
+  sampler: SequentialSampler
+  polling_mode: False
+  zmq_info: null
+
+backend:
+  storage_backend: MooncakeStore
+
+  MooncakeStore:
+    auto_init: true
+    metadata_server: localhost:50050
+    master_server_address: localhost:50051
+    local_hostname: ""
+    protocol: rdma
+    global_segment_size: 86294967296
+    local_buffer_size: 86294967296
+    device_name: ""
+    # GDR enabled — GPU tensors bypass CPU staging
+    use_gdr: true
+    gdr_target_device: null
+    gdr_buffer_size: 4294967296

--- a/scripts/performance_test/perftest_config.yaml
+++ b/scripts/performance_test/perftest_config.yaml
@@ -42,6 +42,12 @@ backend:
     local_buffer_size: 86294967296
     # Network device name. Set to "" to let Mooncake to auto-picks devices
     device_name: ""
+    # GDR (GPU Direct RDMA): bypass CPU staging for GPU tensors
+    use_gdr: false
+    # Target GPU device for GDR GET path (null = use current CUDA device)
+    gdr_target_device: null
+    # Pre-registered GPU staging buffer size in bytes (default: 1GB)
+    gdr_buffer_size: 1073741824
 
   # For RayStore:
   RayStore:

--- a/scripts/performance_test/plot_gdr_breakdown_comparison.py
+++ b/scripts/performance_test/plot_gdr_breakdown_comparison.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""
+Generate side-by-side GDR vs Baseline breakdown comparison chart.
+
+Reads two CSV files produced by breakdown_test.py:
+  1. Baseline run (--device gpu, use_gdr=false)  → GPU data with CPU memcpy path
+  2. GDR run      (--device gpu, use_gdr=true)   → GPU data with GDR staging buffer
+
+Usage:
+  python plot_gdr_breakdown_comparison.py \
+      --baseline breakdown_baseline_gpu.csv \
+      --gdr      breakdown_gdr_gpu.csv \
+      [--scales small medium] \
+      [--output  gdr_breakdown_comparison.png]
+"""
+
+import argparse
+import csv
+import os
+import statistics
+from collections import defaultdict
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def load_csv(path: str) -> list[dict]:
+    rows = []
+    with open(path) as f:
+        for row in csv.DictReader(f):
+            rows.append({k: _auto_num(v) for k, v in row.items()})
+    return rows
+
+
+def _auto_num(v: str):
+    try:
+        return int(v)
+    except ValueError:
+        pass
+    try:
+        return float(v)
+    except ValueError:
+        return v
+
+
+def aggregate(rows: list[dict], scales: list[str]) -> dict:
+    """Aggregate rows per scale, return mean timing dicts."""
+    agg: dict[str, dict[str, list]] = defaultdict(lambda: defaultdict(list))
+
+    for r in rows:
+        sc = r["scale"]
+        if sc not in scales:
+            continue
+        agg[sc]["data_gb"].append(r["data_gb"])
+
+        p_total    = r.get("put.kv_batch_put.total_s", 0) * 1e3
+        p_rmeta    = r.get("put.kv_batch_put.retrieve_meta_s", 0) * 1e3
+        p_kvgen    = r.get("put.storage_mgr.put.key_val_gen_s", 0) * 1e3
+        p_classify = r.get("put.mooncake.put.classify_s", 0) * 1e3
+        p_metap    = r.get("put.storage_mgr.put.meta_processing_s", 0) * 1e3
+        p_notify   = r.get("put.storage_mgr.put.notify_s", 0) * 1e3
+        p_scm      = r.get("put.client.put.set_custom_meta_s", 0) * 1e3
+
+        # Detect GDR vs baseline PUT
+        if r.get("put.mooncake.gdr_batch_put.count", 0) > 0:
+            p_d2d  = r.get("put.mooncake.gdr_put_loop.d2d_total_s", 0) * 1e3
+            p_rdma = r.get("put.mooncake.gdr_put_loop.rdma_total_s", 0) * 1e3
+            p_loop = r.get("put.mooncake.gdr_put_loop.loop_total_s", 0) * 1e3
+            p_pyoh = max(0, p_loop - p_d2d - p_rdma)
+        else:
+            p_d2d  = 0.0
+            p_rdma = r.get("put.mooncake.put_loop.rdma_total_s", 0) * 1e3
+            p_pyoh = r.get("put.mooncake.put_loop.py_overhead_s", 0) * 1e3
+
+        p_other = max(0, p_total - p_rmeta - p_kvgen - p_classify - p_d2d - p_rdma - p_pyoh - p_metap - p_notify - p_scm)
+
+        for k, v in [
+            ("put.total", p_total), ("put.classify", p_classify),
+            ("put.d2d", p_d2d), ("put.rdma", p_rdma), ("put.pyoh", p_pyoh),
+            ("put.other", p_rmeta + p_kvgen + p_metap + p_notify + p_scm),
+            ("put.gap", p_other),
+        ]:
+            agg[sc][k].append(v)
+
+        g_total    = r.get("get.kv_batch_get.total_s", 0) * 1e3
+        g_rmeta    = r.get("get.kv_batch_get.retrieve_meta_s", 0) * 1e3
+        g_keygen   = r.get("get.storage_mgr.key_gen_s", 0) * 1e3
+        g_classify = r.get("get.mooncake.get.classify_s", 0) * 1e3
+        g_scatter  = r.get("get.mooncake.get.scatter_s", 0) * 1e3
+        g_gather   = r.get("get.mooncake.get.gather_s", 0) * 1e3
+        g_merge    = r.get("get.storage_mgr.merge_to_tensordict_s", 0) * 1e3
+
+        if r.get("get.mooncake.gdr_batch_get.count", 0) > 0:
+            g_d2d  = r.get("get.mooncake.gdr_get_loop.d2d_total_s", 0) * 1e3
+            g_rdma = r.get("get.mooncake.gdr_get_loop.rdma_total_s", 0) * 1e3
+            g_loop = r.get("get.mooncake.gdr_get_loop.loop_total_s", 0) * 1e3
+            g_pyoh = max(0, g_loop - g_d2d - g_rdma)
+        else:
+            g_d2d  = 0.0
+            g_rdma = r.get("get.mooncake.get_loop.rdma_total_s", 0) * 1e3
+            g_pyoh = r.get("get.mooncake.get_loop.py_overhead_s", 0) * 1e3
+
+        g_other = max(0, g_total - g_rmeta - g_keygen - g_classify - g_scatter - g_d2d - g_rdma - g_pyoh - g_gather - g_merge)
+
+        for k, v in [
+            ("get.total", g_total), ("get.classify", g_classify + g_scatter),
+            ("get.d2d", g_d2d), ("get.rdma", g_rdma), ("get.pyoh", g_pyoh),
+            ("get.merge", g_merge),
+            ("get.other", g_rmeta + g_keygen + g_gather),
+            ("get.gap", g_other),
+        ]:
+            agg[sc][k].append(v)
+
+    # Mean per scale
+    result = {}
+    for sc in scales:
+        if sc not in agg:
+            continue
+        result[sc] = {k: statistics.mean(v) for k, v in agg[sc].items()}
+    return result
+
+
+def draw_comparison(bl_agg: dict, gdr_agg: dict, scales: list[str], out_path: str):
+    """Draw 4-panel breakdown: PUT baseline/GDR, GET baseline/GDR."""
+    common_scales = [s for s in scales if s in bl_agg and s in gdr_agg]
+    n = len(common_scales)
+    if n == 0:
+        print("No common scales found between baseline and GDR data.")
+        return
+
+    # Colors
+    c_classify = "#E97451"  # coral  - classify (D2H for baseline)
+    c_d2d      = "#17BECF"  # cyan   - D2D copy
+    c_rdma     = "#70AD47"  # green  - RDMA
+    c_pyoh     = "#D9534F"  # red    - Python overhead
+    c_merge    = "#FFD966"  # yellow - merge
+    c_other    = "#9DC3E6"  # light blue - ZMQ + key_gen + etc
+    c_gap      = "#888888"  # gray
+
+    fig, axes = plt.subplots(2, 2, figsize=(16, 10))
+
+    def draw_panel(ax, mode_agg, scales_list, direction, title, rdma_color):
+        """Draw a single stacked bar panel."""
+        x = np.arange(len(scales_list))
+        bw = 0.5
+        bottom = np.zeros(len(scales_list))
+
+        def _bar(vals, label, color, hatch=None):
+            nonlocal bottom
+            arr = np.array(vals)
+            if arr.max() > 0.1:
+                ax.bar(x, arr, bw, bottom=bottom, label=label, color=color,
+                       zorder=3, edgecolor="white", linewidth=0.5, hatch=hatch)
+            bottom += arr
+
+        dir_prefix = direction  # "put" or "get"
+        totals = np.array([mode_agg[s][f"{dir_prefix}.total"] for s in scales_list])
+        gb_arr = np.array([mode_agg[s]["data_gb"] for s in scales_list])
+
+        other_vals   = [mode_agg[s][f"{dir_prefix}.other"] for s in scales_list]
+        classify_vals = [mode_agg[s][f"{dir_prefix}.classify"] for s in scales_list]
+        d2d_vals     = [mode_agg[s][f"{dir_prefix}.d2d"] for s in scales_list]
+        rdma_vals    = [mode_agg[s][f"{dir_prefix}.rdma"] for s in scales_list]
+        pyoh_vals    = [mode_agg[s][f"{dir_prefix}.pyoh"] for s in scales_list]
+        gap_vals     = [mode_agg[s][f"{dir_prefix}.gap"] for s in scales_list]
+
+        _bar(other_vals,    "ZMQ + key_gen + meta",   c_other)
+
+        # classify label depends on whether D2H is involved
+        has_d2d = max(d2d_vals) > 0
+        if has_d2d:
+            _bar(classify_vals, "classify (no D2H)",   c_classify)
+        else:
+            _bar(classify_vals, "classify (incl. D2H)", c_classify)
+
+        _bar(d2d_vals,      "D2D copy (GPU staging)",  c_d2d)
+        _bar(rdma_vals,     "RDMA transfer",           rdma_color)
+        _bar(pyoh_vals,     "Python loop overhead",    c_pyoh, hatch="//")
+
+        if direction == "get":
+            merge_vals = [mode_agg[s].get("get.merge", 0) for s in scales_list]
+            _bar(merge_vals, "merge_to_tensordict",    c_merge)
+
+        if max(gap_vals) > 0.5:
+            _bar(gap_vals,  "remaining gap",           c_gap, hatch="xx")
+
+        # Annotations
+        for i in range(len(scales_list)):
+            bw_val = gb_arr[i] * 8 / (totals[i] / 1e3 + 1e-9)
+            ax.text(i, totals[i] + max(totals) * 0.02,
+                    f"{totals[i]:.0f}ms\n{bw_val:.1f} Gb/s",
+                    ha="center", fontsize=9, fontweight="bold")
+
+            # Percentage labels for large segments
+            cum = 0
+            for vals, color in [
+                (other_vals, None), (classify_vals, "white"),
+                (d2d_vals, "black"), (rdma_vals, "white"), (pyoh_vals, "white"),
+            ]:
+                v = vals[i]
+                pct = v / totals[i] * 100 if totals[i] else 0
+                if pct > 8 and color is not None:
+                    ax.text(i, cum + v / 2, f"{pct:.0f}%",
+                            ha="center", va="center", fontsize=8,
+                            color=color, fontweight="bold")
+                cum += v
+
+        ax.set_title(title, fontsize=12, fontweight="bold")
+        ax.set_ylabel("Time (ms)")
+        ax.set_xticks(x)
+        ax.set_xticklabels([f"{s}\n{gb_arr[i]:.2f} GB" for i, s in enumerate(scales_list)])
+        ax.grid(axis="y", alpha=0.3, zorder=0)
+        ax.legend(fontsize=7.5, loc="upper left")
+        ax.spines["top"].set_visible(False)
+        ax.spines["right"].set_visible(False)
+
+    # Top row: PUT comparison
+    draw_panel(axes[0, 0], bl_agg,  common_scales, "put", "PUT — Baseline (GPU→CPU→RDMA)", c_rdma)
+    draw_panel(axes[0, 1], gdr_agg, common_scales, "put", "PUT — GDR (D2D→GDR RDMA)", c_rdma)
+    # Bottom row: GET comparison
+    draw_panel(axes[1, 0], bl_agg,  common_scales, "get", "GET — Baseline (RDMA→CPU, needs H2D)", "#FF6B35")
+    draw_panel(axes[1, 1], gdr_agg, common_scales, "get", "GET — GDR (GDR RDMA→D2D→GPU)", "#FF6B35")
+
+    # Match y-axis limits across left-right pairs
+    for row in range(2):
+        ymax = max(axes[row, 0].get_ylim()[1], axes[row, 1].get_ylim()[1])
+        axes[row, 0].set_ylim(0, ymax * 1.15)
+        axes[row, 1].set_ylim(0, ymax * 1.15)
+
+    # Speedup annotation
+    speedup_lines = []
+    for sc in common_scales:
+        bl_put = bl_agg[sc]["put.total"]
+        gdr_put = gdr_agg[sc]["put.total"]
+        bl_get = bl_agg[sc]["get.total"]
+        gdr_get = gdr_agg[sc]["get.total"]
+        gb = bl_agg[sc]["data_gb"]
+        speedup_lines.append(
+            f"{sc} ({gb:.2f}GB):  "
+            f"PUT {bl_put:.0f}→{gdr_put:.0f}ms ({bl_put/gdr_put:.1f}x)  "
+            f"GET {bl_get:.0f}→{gdr_get:.0f}ms ({bl_get/gdr_get:.1f}x)"
+        )
+
+    fig.suptitle(
+        "MooncakeStore Breakdown: Baseline (GPU data, CPU memcpy) vs GDR (staging buffer)\n"
+        "2-node RDMA cluster, --device gpu",
+        fontsize=13, fontweight="bold", y=0.99,
+    )
+    fig.text(
+        0.5, 0.01, "\n".join(speedup_lines),
+        ha="center", fontsize=10, fontfamily="monospace",
+        bbox=dict(boxstyle="round,pad=0.5", facecolor="#E2EFDA", edgecolor="#70AD47", alpha=0.9),
+    )
+
+    fig.tight_layout(rect=[0, 0.03 + 0.02 * len(speedup_lines), 1, 0.94])
+    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Chart saved: {out_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="GDR vs Baseline breakdown comparison chart")
+    parser.add_argument("--baseline", required=True, help="Baseline breakdown CSV (--device gpu, use_gdr=false)")
+    parser.add_argument("--gdr",      required=True, help="GDR breakdown CSV (--device gpu, use_gdr=true)")
+    parser.add_argument("--scales",   nargs="+", default=["small", "medium"],
+                        help="Scales to compare (default: small medium)")
+    parser.add_argument("--output",   default=None, help="Output PNG path")
+    args = parser.parse_args()
+
+    bl_rows  = load_csv(args.baseline)
+    gdr_rows = load_csv(args.gdr)
+
+    bl_agg  = aggregate(bl_rows,  args.scales)
+    gdr_agg = aggregate(gdr_rows, args.scales)
+
+    out = args.output or os.path.join(os.path.dirname(args.baseline), "gdr_breakdown_comparison.png")
+    draw_comparison(bl_agg, gdr_agg, args.scales, out)
+
+    # Print summary table
+    print(f"\n{'='*80}")
+    print("BREAKDOWN COMPARISON: Baseline (GPU data) vs GDR")
+    print(f"{'='*80}")
+    for sc in args.scales:
+        if sc not in bl_agg or sc not in gdr_agg:
+            continue
+        bl, gdr = bl_agg[sc], gdr_agg[sc]
+        gb = bl["data_gb"]
+        print(f"\n{sc} ({gb:.2f} GB):")
+        for direction, label in [("put", "PUT"), ("get", "GET")]:
+            bl_t = bl[f"{direction}.total"]
+            gdr_t = gdr[f"{direction}.total"]
+            bl_bw = gb * 8 / (bl_t / 1e3 + 1e-9)
+            gdr_bw = gb * 8 / (gdr_t / 1e3 + 1e-9)
+            print(f"  {label}: {bl_t:.0f}ms ({bl_bw:.1f} Gb/s) → {gdr_t:.0f}ms ({gdr_bw:.1f} Gb/s)  [{bl_t/gdr_t:.1f}x]")
+            print(f"    Baseline: classify(D2H)={bl[f'{direction}.classify']:.0f}ms  RDMA={bl[f'{direction}.rdma']:.0f}ms  pyoh={bl[f'{direction}.pyoh']:.0f}ms")
+            print(f"    GDR:      classify={gdr[f'{direction}.classify']:.0f}ms  D2D={gdr[f'{direction}.d2d']:.0f}ms  RDMA={gdr[f'{direction}.rdma']:.0f}ms  pyoh={gdr[f'{direction}.pyoh']:.0f}ms")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/performance_test/plot_gdr_comparison.py
+++ b/scripts/performance_test/plot_gdr_comparison.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Generate GDR vs Baseline comparison chart from A/B test CSV results."""
+
+import csv
+import os
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+RESULTS_DIR = os.path.dirname(os.path.abspath(__file__))
+WARMUP_ITERS = 1  # skip first iteration (warmup)
+
+
+def load_csv(filename):
+    path = os.path.join(RESULTS_DIR, filename)
+    rows = []
+    with open(path) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            rows.append(row)
+    return rows
+
+
+def avg_stable(rows, field):
+    """Average field over non-warmup iterations."""
+    vals = [float(r[field]) for r in rows[WARMUP_ITERS:]]
+    return np.mean(vals)
+
+
+# Load data
+baseline_small = load_csv("mooncake_baseline_small.csv")
+baseline_medium = load_csv("mooncake_baseline_medium.csv")
+gdr_small = load_csv("mooncake_gdr_small.csv")
+gdr_medium = load_csv("mooncake_gdr_medium.csv")
+
+# Compute averages (skip warmup iter 1)
+data = {
+    "Small\n(0.28 GB)": {
+        "Baseline PUT": avg_stable(baseline_small, "put_gbit_per_sec"),
+        "GDR PUT": avg_stable(gdr_small, "put_gbit_per_sec"),
+        "Baseline GET": avg_stable(baseline_small, "get_gbit_per_sec"),
+        "GDR GET": avg_stable(gdr_small, "get_gbit_per_sec"),
+    },
+    "Medium\n(7.5 GB)": {
+        "Baseline PUT": avg_stable(baseline_medium, "put_gbit_per_sec"),
+        "GDR PUT": avg_stable(gdr_medium, "put_gbit_per_sec"),
+        "Baseline GET": avg_stable(baseline_medium, "get_gbit_per_sec"),
+        "GDR GET": avg_stable(gdr_medium, "get_gbit_per_sec"),
+    },
+}
+
+# Also compute per-iteration data for the detailed subplot
+iter_labels_med = [f"Iter {i+1}" for i in range(len(baseline_medium))]
+
+# ── Figure: 2 subplots ──
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 6), gridspec_kw={"width_ratios": [1, 1.3]})
+fig.suptitle("TransferQueue: GDR Staging Buffer vs Baseline (CPU memcpy)\n2-node RDMA cluster",
+             fontsize=14, fontweight="bold", y=0.98)
+
+# ── Left: Grouped bar chart (averaged, warmup excluded) ──
+scenarios = list(data.keys())
+x = np.arange(len(scenarios))
+width = 0.18
+
+colors = {"Baseline PUT": "#5B9BD5", "GDR PUT": "#2E75B6",
+          "Baseline GET": "#ED7D31", "GDR GET": "#C55A11"}
+
+for i, metric in enumerate(["Baseline PUT", "GDR PUT", "Baseline GET", "GDR GET"]):
+    vals = [data[s][metric] for s in scenarios]
+    bars = ax1.bar(x + (i - 1.5) * width, vals, width, label=metric, color=colors[metric],
+                   edgecolor="white", linewidth=0.5)
+    for bar, val in zip(bars, vals):
+        ax1.text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 0.8,
+                 f"{val:.1f}", ha="center", va="bottom", fontsize=8, fontweight="bold")
+
+ax1.set_ylabel("Throughput (Gb/s)", fontsize=11)
+ax1.set_xticks(x)
+ax1.set_xticklabels(scenarios, fontsize=10)
+ax1.set_title("Average Throughput (iters 2-4)", fontsize=11)
+ax1.legend(fontsize=8, ncol=2, loc="upper left")
+ax1.set_ylim(0, max(max(data[s].values()) for s in scenarios) * 1.25)
+ax1.grid(axis="y", alpha=0.3)
+ax1.spines["top"].set_visible(False)
+ax1.spines["right"].set_visible(False)
+
+# ── Right: Per-iteration line chart for Medium ──
+iters = list(range(1, len(baseline_medium) + 1))
+
+bl_put = [float(r["put_gbit_per_sec"]) for r in baseline_medium]
+bl_get = [float(r["get_gbit_per_sec"]) for r in baseline_medium]
+gdr_put = [float(r["put_gbit_per_sec"]) for r in gdr_medium]
+gdr_get = [float(r["get_gbit_per_sec"]) for r in gdr_medium]
+
+ax2.plot(iters, bl_put, "s--", color="#5B9BD5", label="Baseline PUT", markersize=7, linewidth=1.5)
+ax2.plot(iters, gdr_put, "s-", color="#2E75B6", label="GDR PUT", markersize=7, linewidth=2)
+ax2.plot(iters, bl_get, "o--", color="#ED7D31", label="Baseline GET", markersize=7, linewidth=1.5)
+ax2.plot(iters, gdr_get, "o-", color="#C55A11", label="GDR GET", markersize=7, linewidth=2)
+
+# Annotate key values
+for it, val in zip(iters, gdr_put):
+    ax2.annotate(f"{val:.1f}", (it, val), textcoords="offset points",
+                 xytext=(0, 10), ha="center", fontsize=8, color="#2E75B6", fontweight="bold")
+for it, val in zip(iters, gdr_get):
+    ax2.annotate(f"{val:.1f}", (it, val), textcoords="offset points",
+                 xytext=(0, -15), ha="center", fontsize=8, color="#C55A11", fontweight="bold")
+
+ax2.axvspan(0.5, 1.5, alpha=0.08, color="gray")
+ax2.text(1, 2, "warmup", ha="center", fontsize=8, color="gray", fontstyle="italic")
+
+ax2.set_xlabel("Iteration", fontsize=11)
+ax2.set_ylabel("Throughput (Gb/s)", fontsize=11)
+ax2.set_title("Medium (7.5 GB) — Per-Iteration Detail", fontsize=11)
+ax2.set_xticks(iters)
+ax2.legend(fontsize=8, loc="center right")
+ax2.set_ylim(0, max(max(gdr_put), max(gdr_get)) * 1.25)
+ax2.grid(alpha=0.3)
+ax2.spines["top"].set_visible(False)
+ax2.spines["right"].set_visible(False)
+
+# ── Speedup annotation box ──
+# Compute speedups for medium (iters 2-4 avg)
+bl_put_avg = np.mean(bl_put[1:])
+gdr_put_avg = np.mean(gdr_put[1:])
+bl_get_avg = np.mean(bl_get[1:])
+gdr_get_avg = np.mean(gdr_get[1:])
+
+speedup_text = (
+    f"Medium (iters 2-4 avg):\n"
+    f"  PUT: {bl_put_avg:.1f} -> {gdr_put_avg:.1f} Gb/s  ({gdr_put_avg/bl_put_avg:.1f}x)\n"
+    f"  GET: {bl_get_avg:.1f} -> {gdr_get_avg:.1f} Gb/s  ({gdr_get_avg/bl_get_avg:.1f}x)"
+)
+fig.text(0.5, 0.01, speedup_text, ha="center", fontsize=10,
+         fontfamily="monospace",
+         bbox=dict(boxstyle="round,pad=0.5", facecolor="#E2EFDA", edgecolor="#70AD47", alpha=0.9))
+
+plt.tight_layout(rect=[0, 0.08, 1, 0.93])
+out_path = os.path.join(RESULTS_DIR, "gdr_comparison.png")
+fig.savefig(out_path, dpi=150, bbox_inches="tight")
+print(f"Chart saved to: {out_path}")
+
+# Also print summary table
+print("\n" + "=" * 70)
+print("SUMMARY: GDR Staging Buffer vs Baseline (averages, iters 2-4)")
+print("=" * 70)
+for scenario in scenarios:
+    d = data[scenario]
+    put_speedup = d["GDR PUT"] / d["Baseline PUT"]
+    get_speedup = d["GDR GET"] / d["Baseline GET"]
+    print(f"\n{scenario.replace(chr(10), ' ')}:")
+    print(f"  PUT: {d['Baseline PUT']:6.1f} -> {d['GDR PUT']:6.1f} Gb/s  ({put_speedup:.2f}x)")
+    print(f"  GET: {d['Baseline GET']:6.1f} -> {d['GDR GET']:6.1f} Gb/s  ({get_speedup:.2f}x)")
+print()

--- a/scripts/performance_test/run_gdr_breakdown_comparison.sh
+++ b/scripts/performance_test/run_gdr_breakdown_comparison.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# A/B breakdown comparison: Baseline (GPU data, CPU memcpy) vs GDR (staging buffer).
+#
+# Runs breakdown_test.py twice with GPU data:
+#   1. Baseline config (use_gdr=false) — measures D2H + host RDMA overhead
+#   2. GDR config      (use_gdr=true)  — measures D2D + GDR RDMA
+#
+# Then generates a side-by-side comparison breakdown chart.
+#
+# Prerequisites:
+#   - 2-node Ray cluster with GPU, RDMA, nvidia_peermem loaded
+#   - mooncake-transfer-engine with CUDA support
+#
+# Usage:
+#   ./run_gdr_breakdown_comparison.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESULTS_DIR="${SCRIPT_DIR}/results"
+BREAKDOWN_PY="${SCRIPT_DIR}/breakdown_test.py"
+BASELINE_CONFIG="${SCRIPT_DIR}/mooncake_config.yaml"
+GDR_CONFIG="${SCRIPT_DIR}/mooncake_gdr_config.yaml"
+COMPARISON_PY="${RESULTS_DIR}/plot_gdr_breakdown_comparison.py"
+
+mkdir -p "${RESULTS_DIR}"
+
+# Auto-detect head and worker IPs from Ray cluster
+read -r HEAD_IP WORKER_IP <<< $(python3 -c "
+import ray
+ray.init(address='auto', logging_level='WARNING')
+nodes = ray.nodes()
+head = worker = None
+for n in nodes:
+    addr = n['NodeManagerAddress']
+    res = n['Resources']
+    if 'node:__internal_head__' in res:
+        for k in res:
+            if k.startswith('node:') and k != 'node:__internal_head__':
+                head = k.split('node:', 1)[1]
+                break
+    else:
+        worker = addr
+if head is None:
+    print('ERROR: head node not found', flush=True)
+    exit(1)
+if worker is None:
+    worker = head
+print(head, worker)
+")
+
+echo "Head node:   $HEAD_IP"
+echo "Worker node: $WORKER_IP"
+
+SCALES="${GDR_BREAKDOWN_SCALES:-small medium}"
+NUM_WARMUP="${GDR_BREAKDOWN_WARMUP:-1}"
+NUM_ITERS="${GDR_BREAKDOWN_ITERS:-3}"
+
+echo ""
+echo "============================================"
+echo " Phase 1: Baseline (GPU data, use_gdr=false)"
+echo "============================================"
+python "${BREAKDOWN_PY}" \
+    --backend_config="${BASELINE_CONFIG}" \
+    --head_node_ip="${HEAD_IP}" \
+    --worker_node_ip="${WORKER_IP}" \
+    --device=gpu \
+    --num_warmup="${NUM_WARMUP}" \
+    --num_iters="${NUM_ITERS}" \
+    --scales ${SCALES} \
+    --output_dir="${RESULTS_DIR}"
+
+# Rename output files to baseline
+mv "${RESULTS_DIR}/breakdown_results.csv"          "${RESULTS_DIR}/breakdown_baseline_gpu.csv"
+mv "${RESULTS_DIR}/breakdown_raw_tqtiming.log"     "${RESULTS_DIR}/breakdown_baseline_gpu_raw.log"
+mv "${RESULTS_DIR}/breakdown_chart.png"             "${RESULTS_DIR}/breakdown_baseline_gpu_chart.png"
+
+sleep 10
+
+echo ""
+echo "============================================"
+echo " Phase 2: GDR (GPU data, use_gdr=true)"
+echo "============================================"
+python "${BREAKDOWN_PY}" \
+    --backend_config="${GDR_CONFIG}" \
+    --head_node_ip="${HEAD_IP}" \
+    --worker_node_ip="${WORKER_IP}" \
+    --device=gpu \
+    --num_warmup="${NUM_WARMUP}" \
+    --num_iters="${NUM_ITERS}" \
+    --scales ${SCALES} \
+    --output_dir="${RESULTS_DIR}"
+
+# Rename output files to GDR
+mv "${RESULTS_DIR}/breakdown_results.csv"          "${RESULTS_DIR}/breakdown_gdr_gpu.csv"
+mv "${RESULTS_DIR}/breakdown_raw_tqtiming.log"     "${RESULTS_DIR}/breakdown_gdr_gpu_raw.log"
+mv "${RESULTS_DIR}/breakdown_chart.png"             "${RESULTS_DIR}/breakdown_gdr_gpu_chart.png"
+
+echo ""
+echo "============================================"
+echo " Phase 3: Comparison Chart"
+echo "============================================"
+python "${COMPARISON_PY}" \
+    --baseline="${RESULTS_DIR}/breakdown_baseline_gpu.csv" \
+    --gdr="${RESULTS_DIR}/breakdown_gdr_gpu.csv" \
+    --scales ${SCALES} \
+    --output="${RESULTS_DIR}/gdr_breakdown_comparison.png"
+
+echo ""
+echo "============================================"
+echo " Results in: ${RESULTS_DIR}/"
+echo "   breakdown_baseline_gpu.csv        (baseline breakdown data)"
+echo "   breakdown_gdr_gpu.csv             (GDR breakdown data)"
+echo "   breakdown_baseline_gpu_chart.png  (baseline breakdown chart)"
+echo "   breakdown_gdr_gpu_chart.png       (GDR breakdown chart)"
+echo "   gdr_breakdown_comparison.png      (side-by-side comparison)"
+echo "============================================"

--- a/scripts/performance_test/run_gdr_comparison.sh
+++ b/scripts/performance_test/run_gdr_comparison.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# A/B comparison: MooncakeStore with vs without GDR.
+#
+# Usage:
+#   ./run_gdr_comparison.sh [extra args for perftest.py]
+#
+# Prerequisites:
+#   - 2-node Ray cluster with GPU, RDMA, nvidia_peermem loaded
+#   - mooncake-transfer-engine built with USE_CUDA=ON
+#
+# Output: two CSV files in results/ — one for baseline, one for GDR.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESULTS_DIR="${SCRIPT_DIR}/results"
+PERFTEST_PY="${SCRIPT_DIR}/perftest.py"
+BASELINE_CONFIG="${SCRIPT_DIR}/mooncake_config.yaml"
+GDR_CONFIG="${SCRIPT_DIR}/mooncake_gdr_config.yaml"
+
+mkdir -p "${RESULTS_DIR}"
+
+# Auto-detect head and worker IPs from Ray cluster
+read -r HEAD_IP WORKER_IP <<< $(python3 -c "
+import ray
+ray.init(address='auto', logging_level='WARNING')
+nodes = ray.nodes()
+head = worker = None
+for n in nodes:
+    addr = n['NodeManagerAddress']
+    res = n['Resources']
+    if 'node:__internal_head__' in res:
+        for k in res:
+            if k.startswith('node:') and k != 'node:__internal_head__':
+                head = k.split('node:', 1)[1]
+                break
+    else:
+        worker = addr
+if head is None:
+    print('ERROR: head node not found', flush=True)
+    exit(1)
+if worker is None:
+    worker = head
+print(head, worker)
+")
+
+echo "Head node:   $HEAD_IP"
+echo "Worker node: $WORKER_IP"
+
+NUM_ITERS="${NUM_TEST_ITERATIONS:-4}"
+
+# Test matrix: batch_size, field_num, seq_len, label
+SETTINGS=(
+    "1024,9,8192,Small"
+    "4096,15,32768,Medium"
+)
+
+for setting in "${SETTINGS[@]}"; do
+    IFS=',' read -r batch_size field_num seq_len label <<< "$setting"
+    data_desc="batch=${batch_size},fields=${field_num},seq=${seq_len}"
+
+    echo ""
+    echo "============================================"
+    echo " ${label}: ${data_desc}"
+    echo "============================================"
+
+    # --- Baseline (no GDR) ---
+    echo ">>> Baseline (use_gdr=false)"
+    python "${PERFTEST_PY}" \
+        --backend_config="${BASELINE_CONFIG}" \
+        --backend=MooncakeStore \
+        --device=gpu \
+        --global_batch_size="${batch_size}" \
+        --field_num="${field_num}" \
+        --seq_len="${seq_len}" \
+        --num_test_iterations="${NUM_ITERS}" \
+        --head_node_ip="${HEAD_IP}" \
+        --worker_node_ip="${WORKER_IP}" \
+        --output_csv="${RESULTS_DIR}/mooncake_baseline_${label,,}.csv" \
+        "$@"
+
+    sleep 5
+
+    # --- GDR ---
+    echo ">>> GDR (use_gdr=true)"
+    python "${PERFTEST_PY}" \
+        --backend_config="${GDR_CONFIG}" \
+        --backend=MooncakeStore \
+        --device=gpu \
+        --global_batch_size="${batch_size}" \
+        --field_num="${field_num}" \
+        --seq_len="${seq_len}" \
+        --num_test_iterations="${NUM_ITERS}" \
+        --head_node_ip="${HEAD_IP}" \
+        --worker_node_ip="${WORKER_IP}" \
+        --output_csv="${RESULTS_DIR}/mooncake_gdr_${label,,}.csv" \
+        "$@"
+
+    sleep 5
+done
+
+echo ""
+echo "============================================"
+echo " Results in: ${RESULTS_DIR}/"
+echo "   mooncake_baseline_*.csv  (no GDR)"
+echo "   mooncake_gdr_*.csv       (with GDR)"
+echo "============================================"
+echo ""
+echo "Compare [TQ-TIMING] lines in stdout:"
+echo "  Baseline: mooncake::batch_put_tensor  → bw=...Gb/s"
+echo "  GDR:      mooncake::gdr_batch_put     → bw=...Gb/s"

--- a/tests/test_mooncake_gdr.py
+++ b/tests/test_mooncake_gdr.py
@@ -1,0 +1,213 @@
+# Copyright 2025 The TransferQueue Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for GDR (GPU Direct RDMA) support in MooncakeStoreClient.
+
+Unit tests for TensorMetadata pack/unpack and dtype mapping can run anywhere.
+Integration tests that need a live MooncakeStore + CUDA are marked accordingly.
+"""
+
+import ctypes
+import struct
+
+import pytest
+import torch
+
+from transfer_queue.storage.clients.mooncake_client import (
+    TENSOR_METADATA_SIZE,
+    _MC_ENUM_TO_TORCH_DTYPE,
+    _TENSOR_METADATA_FMT,
+    _TORCH_DTYPE_TO_MC_ENUM,
+    _pack_tensor_metadata,
+    _unpack_tensor_metadata,
+)
+
+
+# ---------------------------------------------------------------------------
+# TensorMetadata binary layout tests
+# ---------------------------------------------------------------------------
+class TestTensorMetadataLayout:
+    """Verify that Python packing matches the C++ TensorMetadata struct."""
+
+    def test_struct_size_is_40_bytes(self):
+        assert struct.calcsize(_TENSOR_METADATA_FMT) == 40
+        assert TENSOR_METADATA_SIZE == 40
+
+    def test_field_offsets(self):
+        """dtype at 0, ndim at 4, shape[0] at 8."""
+        packed = _pack_tensor_metadata(torch.float16, (10, 20))
+        # dtype = 11 (FLOAT16), ndim = 2
+        dtype_val = struct.unpack_from("<i", packed, 0)[0]
+        ndim_val = struct.unpack_from("<i", packed, 4)[0]
+        shape0 = struct.unpack_from("<q", packed, 8)[0]
+        shape1 = struct.unpack_from("<q", packed, 16)[0]
+        shape2 = struct.unpack_from("<q", packed, 24)[0]
+        shape3 = struct.unpack_from("<q", packed, 32)[0]
+        assert dtype_val == 11
+        assert ndim_val == 2
+        assert shape0 == 10
+        assert shape1 == 20
+        assert shape2 == -1
+        assert shape3 == -1
+
+
+# ---------------------------------------------------------------------------
+# Dtype enum mapping tests
+# ---------------------------------------------------------------------------
+class TestDtypeEnumMapping:
+    """Ensure torch ↔ Mooncake enum mapping is complete and consistent."""
+
+    @pytest.mark.parametrize(
+        "dtype,expected_enum",
+        [
+            (torch.float32, 0),
+            (torch.float64, 1),
+            (torch.int8, 2),
+            (torch.uint8, 3),
+            (torch.int16, 4),
+            (torch.uint16, 5),
+            (torch.int32, 6),
+            (torch.uint32, 7),
+            (torch.int64, 8),
+            (torch.uint64, 9),
+            (torch.bool, 10),
+            (torch.float16, 11),
+            (torch.bfloat16, 12),
+        ],
+    )
+    def test_dtype_to_enum(self, dtype, expected_enum):
+        assert _TORCH_DTYPE_TO_MC_ENUM[dtype] == expected_enum
+
+    def test_roundtrip_all_dtypes(self):
+        for dtype, enum_val in _TORCH_DTYPE_TO_MC_ENUM.items():
+            assert _MC_ENUM_TO_TORCH_DTYPE[enum_val] is dtype
+
+    @pytest.mark.skipif(not hasattr(torch, "float8_e4m3fn"), reason="float8 not available")
+    def test_float8_e4m3fn_mapping(self):
+        assert _TORCH_DTYPE_TO_MC_ENUM[torch.float8_e4m3fn] == 13
+
+    @pytest.mark.skipif(not hasattr(torch, "float8_e5m2"), reason="float8 not available")
+    def test_float8_e5m2_mapping(self):
+        assert _TORCH_DTYPE_TO_MC_ENUM[torch.float8_e5m2] == 14
+
+
+# ---------------------------------------------------------------------------
+# pack / unpack round-trip tests
+# ---------------------------------------------------------------------------
+class TestPackUnpack:
+
+    @pytest.mark.parametrize(
+        "dtype",
+        [torch.float32, torch.float16, torch.bfloat16, torch.int64, torch.int32, torch.bool],
+    )
+    @pytest.mark.parametrize(
+        "shape",
+        [(), (1024,), (32, 128), (2, 3, 4), (2, 3, 4, 5)],
+    )
+    def test_roundtrip(self, dtype, shape):
+        packed = _pack_tensor_metadata(dtype, shape)
+        assert len(packed) == TENSOR_METADATA_SIZE
+        out_dtype, out_shape = _unpack_tensor_metadata(packed)
+        assert out_dtype is dtype
+        assert out_shape == shape
+
+    def test_scalar_tensor_metadata(self):
+        """ndim=0 → all shape slots are -1."""
+        packed = _pack_tensor_metadata(torch.float32, ())
+        _, ndim, *shape_raw = struct.unpack(_TENSOR_METADATA_FMT, packed)
+        assert ndim == 0
+        assert shape_raw == [-1, -1, -1, -1]
+
+    def test_rejects_5d_tensor(self):
+        with pytest.raises(ValueError, match="at most 4 dimensions"):
+            _pack_tensor_metadata(torch.float32, (1, 2, 3, 4, 5))
+
+    def test_rejects_unsupported_dtype(self):
+        with pytest.raises(ValueError, match="Unsupported dtype"):
+            _pack_tensor_metadata(torch.complex64, (10,))
+
+    def test_unpack_rejects_unknown_enum(self):
+        bad_data = struct.pack(_TENSOR_METADATA_FMT, 999, 1, 10, -1, -1, -1)
+        with pytest.raises(ValueError, match="Unknown dtype enum"):
+            _unpack_tensor_metadata(bad_data)
+
+
+# ---------------------------------------------------------------------------
+# Batch metadata buffer tests (ctypes layout used by GDR path)
+# ---------------------------------------------------------------------------
+class TestBatchMetadataBuffer:
+    """Verify that packing multiple metadata entries into a contiguous
+    bytearray produces correct per-slot pointers."""
+
+    def test_contiguous_buffer_packing(self):
+        dtypes = [torch.float32, torch.bfloat16, torch.int64]
+        shapes = [(100,), (32, 64), (2, 3, 4)]
+        n = len(dtypes)
+
+        meta_buf = bytearray(TENSOR_METADATA_SIZE * n)
+        meta_ctypes = (ctypes.c_char * len(meta_buf)).from_buffer(meta_buf)
+        meta_ptr = ctypes.addressof(meta_ctypes)
+
+        for j, (dtype, shape) in enumerate(zip(dtypes, shapes)):
+            offset = j * TENSOR_METADATA_SIZE
+            meta_bytes = _pack_tensor_metadata(dtype, shape)
+            meta_buf[offset : offset + TENSOR_METADATA_SIZE] = meta_bytes
+
+        # Read back each slot and verify
+        for j, (dtype, shape) in enumerate(zip(dtypes, shapes)):
+            offset = j * TENSOR_METADATA_SIZE
+            slot_bytes = bytes(meta_buf[offset : offset + TENSOR_METADATA_SIZE])
+            out_dtype, out_shape = _unpack_tensor_metadata(slot_bytes)
+            assert out_dtype is dtype
+            assert out_shape == shape
+
+        # Verify pointer arithmetic is consistent
+        assert meta_ptr > 0
+        for j in range(n):
+            slot_ptr = meta_ptr + j * TENSOR_METADATA_SIZE
+            assert slot_ptr == meta_ptr + j * 40
+
+
+# ---------------------------------------------------------------------------
+# GPU tensor handling (requires CUDA)
+# ---------------------------------------------------------------------------
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestGDRTensorHandling:
+
+    def test_gpu_tensor_data_ptr_nonzero(self):
+        t = torch.randn(1024, device="cuda:0")
+        assert t.data_ptr() != 0
+
+    def test_contiguous_gpu_tensor(self):
+        t = torch.randn(10, 10, device="cuda:0").t()
+        assert not t.is_contiguous()
+        t_c = t.contiguous()
+        assert t_c.is_contiguous()
+        assert t_c.data_ptr() != 0
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    def test_metadata_for_gpu_tensor(self, dtype):
+        t = torch.zeros(32, 64, dtype=dtype, device="cuda:0")
+        packed = _pack_tensor_metadata(t.dtype, tuple(t.shape))
+        out_dtype, out_shape = _unpack_tensor_metadata(packed)
+        assert out_dtype is dtype
+        assert out_shape == (32, 64)
+
+    def test_pre_allocate_gpu_tensor_for_get(self):
+        """Simulate the GET path: pre-allocate, then verify data_ptr is usable."""
+        shape = [16, 128]
+        dtype = torch.bfloat16
+        t = torch.empty(shape, dtype=dtype, device="cuda:0")
+        assert t.data_ptr() != 0
+        assert t.numel() * t.element_size() == 16 * 128 * 2

--- a/transfer_queue/config.yaml
+++ b/transfer_queue/config.yaml
@@ -42,6 +42,15 @@ backend:
     local_buffer_size: 1073741824
     # Network device name. Set to "" to let Mooncake to auto-picks devices
     device_name: ""
+    # GDR (GPU Direct RDMA): bypass CPU staging for GPU tensors.
+    # Requires nvidia_peermem kernel module and CUDA-enabled mooncake build.
+    use_gdr: false
+    # Target GPU device for GDR GET path (null = use current CUDA device)
+    gdr_target_device: null
+    # Size of the pre-registered GPU staging buffer in bytes (default: 1GB).
+    # Tensors are D2D-copied into this buffer before RDMA to avoid per-tensor
+    # ibv_reg_mr overhead. Increase if single tensors exceed this size.
+    gdr_buffer_size: 1073741824
 
   # For RayStore:
   RayStore:

--- a/transfer_queue/storage/clients/mooncake_client.py
+++ b/transfer_queue/storage/clients/mooncake_client.py
@@ -13,9 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ctypes
 import logging
 import os
 import pickle
+import struct
+import time
 from typing import Any, Optional
 
 import torch
@@ -34,6 +37,82 @@ except ImportError:
     MOONCAKE_STORE_IMPORTED = False
 
 BATCH_SIZE_LIMIT: int = 500
+
+# ---------------------------------------------------------------------------
+# GDR (GPU Direct RDMA) helpers
+# TensorMetadata layout must match the C++ struct in
+# mooncake-integration/integration_utils.h:
+#   struct TensorMetadata { int32_t dtype; int32_t ndim; int64_t shape[4]; };
+# ---------------------------------------------------------------------------
+TENSOR_METADATA_SIZE: int = 40  # 4 + 4 + 8*4 = 40 bytes
+_TENSOR_METADATA_FMT: str = "<ii4q"  # little-endian: int32, int32, 4×int64
+
+_TORCH_DTYPE_TO_MC_ENUM: dict[torch.dtype, int] = {
+    torch.float32: 0,
+    torch.float64: 1,
+    torch.int8: 2,
+    torch.uint8: 3,
+    torch.int16: 4,
+    torch.uint16: 5,
+    torch.int32: 6,
+    torch.uint32: 7,
+    torch.int64: 8,
+    torch.uint64: 9,
+    torch.bool: 10,
+    torch.float16: 11,
+    torch.bfloat16: 12,
+}
+if hasattr(torch, "float8_e4m3fn"):
+    _TORCH_DTYPE_TO_MC_ENUM[torch.float8_e4m3fn] = 13
+if hasattr(torch, "float8_e5m2"):
+    _TORCH_DTYPE_TO_MC_ENUM[torch.float8_e5m2] = 14
+
+_MC_ENUM_TO_TORCH_DTYPE: dict[int, torch.dtype] = {v: k for k, v in _TORCH_DTYPE_TO_MC_ENUM.items()}
+
+
+def _pack_tensor_metadata(dtype: torch.dtype, shape: tuple[int, ...]) -> bytes:
+    """Pack a TensorMetadata struct matching the C++ layout."""
+    dtype_enum = _TORCH_DTYPE_TO_MC_ENUM.get(dtype)
+    if dtype_enum is None:
+        raise ValueError(f"Unsupported dtype for GDR: {dtype}")
+    ndim = len(shape)
+    if ndim > 4:
+        raise ValueError(f"TensorMetadata supports at most 4 dimensions, got {ndim}")
+    shape_padded = list(shape) + [-1] * (4 - ndim)
+    return struct.pack(_TENSOR_METADATA_FMT, dtype_enum, ndim, *shape_padded)
+
+
+def _unpack_tensor_metadata(data: bytes) -> tuple[torch.dtype, tuple[int, ...]]:
+    """Unpack a TensorMetadata struct."""
+    dtype_enum, ndim, *shape_raw = struct.unpack(_TENSOR_METADATA_FMT, data)
+    dtype = _MC_ENUM_TO_TORCH_DTYPE.get(dtype_enum)
+    if dtype is None:
+        raise ValueError(f"Unknown dtype enum: {dtype_enum}")
+    shape = tuple(shape_raw[:ndim])
+    return dtype, shape
+
+
+# Pre-computed element sizes for all supported dtypes (avoids per-call tensor alloc)
+_DTYPE_ELEMENT_SIZE: dict[torch.dtype, int] = {}
+for _dt in _TORCH_DTYPE_TO_MC_ENUM:
+    _DTYPE_ELEMENT_SIZE[_dt] = torch.tensor([], dtype=_dt).element_size()
+
+_libcudart = None
+
+
+def _cuda_d2d_copy(dst_ptr: int, src_ptr: int, num_bytes: int):
+    """Synchronous device-to-device memcpy via cudart."""
+    global _libcudart
+    if _libcudart is None:
+        _libcudart = ctypes.CDLL("libcudart.so")
+    ret = _libcudart.cudaMemcpy(
+        ctypes.c_void_p(dst_ptr),
+        ctypes.c_void_p(src_ptr),
+        ctypes.c_size_t(num_bytes),
+        ctypes.c_int(3),  # cudaMemcpyDeviceToDevice
+    )
+    if ret != 0:
+        raise RuntimeError(f"cudaMemcpy D2D failed with error code {ret}")
 
 
 @StorageClientFactory.register("MooncakeStoreClient")
@@ -96,6 +175,36 @@ class MooncakeStoreClient(TransferQueueStorageKVClient):
         if ret != 0:
             raise RuntimeError(f"Mooncake store setup failed with error code: {ret}")
 
+        # GDR (GPU Direct RDMA) configuration
+        self._use_gdr = config.get("use_gdr", False)
+        self._gdr_target_device = config.get("gdr_target_device", None)
+        self._gdr_staging_buf = None
+        self._gdr_staging_ptr = 0
+        self._gdr_staging_size = 0
+        self._gdr_meta_ctypes = None
+        self._gdr_meta_ptr = 0
+        self._gdr_meta_size = 0
+
+        if self._use_gdr:
+            gdr_buf_bytes = int(config.get("gdr_buffer_size", 1 * 1024 * 1024 * 1024))
+            device = self._gdr_target_device or f"cuda:{torch.cuda.current_device()}"
+            # GPU staging buffer — registered once, reused for every GDR transfer
+            self._gdr_staging_buf = torch.empty(gdr_buf_bytes, dtype=torch.uint8, device=device)
+            self._gdr_staging_ptr = self._gdr_staging_buf.data_ptr()
+            self._gdr_staging_size = gdr_buf_bytes
+            self._store.register_buffer(self._gdr_staging_ptr, self._gdr_staging_size)
+            # CPU metadata buffer — enough for BATCH_SIZE_LIMIT tensors
+            meta_capacity = TENSOR_METADATA_SIZE * BATCH_SIZE_LIMIT
+            self._gdr_meta_buf = bytearray(meta_capacity)
+            self._gdr_meta_ctypes = (ctypes.c_char * meta_capacity).from_buffer(self._gdr_meta_buf)
+            self._gdr_meta_ptr = ctypes.addressof(self._gdr_meta_ctypes)
+            self._gdr_meta_size = meta_capacity
+            self._store.register_buffer(self._gdr_meta_ptr, self._gdr_meta_size)
+            logger.info(
+                f"GDR staging buffer: {gdr_buf_bytes / (1024**2):.0f}MB GPU + "
+                f"{meta_capacity / 1024:.0f}KB CPU metadata on {device}"
+            )
+
     def put(self, keys: list[str], values: list[Any]) -> Optional[list[Any]]:
         """Stores multiple key-value pairs to MooncakeStore.
 
@@ -109,22 +218,32 @@ class MooncakeStoreClient(TransferQueueStorageKVClient):
         if len(keys) != len(values):
             raise ValueError("Number of keys must match number of values")
 
+        _t_classify0 = time.perf_counter()
         tensor_keys = []
         tensor_values = []
+        gdr_tensor_keys = []
+        gdr_tensor_values = []
         non_tensor_keys = []
         non_tensor_values = []
 
         for key, value in zip(keys, values, strict=True):
             if isinstance(value, torch.Tensor):
                 tensor = value.contiguous()
-                # TODO: use gpu direct rdma instead
-                if tensor.device.type == "cuda":
-                    tensor = tensor.cpu()
-                tensor_keys.append(key)
-                tensor_values.append(tensor)
+                if self._use_gdr and tensor.device.type == "cuda" and tensor.numel() > 0:
+                    gdr_tensor_keys.append(key)
+                    gdr_tensor_values.append(tensor)
+                else:
+                    if tensor.device.type == "cuda":
+                        tensor = tensor.cpu()
+                    tensor_keys.append(key)
+                    tensor_values.append(tensor)
             else:
                 non_tensor_keys.append(key)
                 non_tensor_values.append(pickle.dumps(value))
+        _t_classify1 = time.perf_counter()
+
+        if gdr_tensor_keys:
+            self._batch_put_tensors_gdr(gdr_tensor_keys, gdr_tensor_values)
 
         if tensor_keys:
             self._batch_put_tensors(tensor_keys, tensor_values)
@@ -132,20 +251,141 @@ class MooncakeStoreClient(TransferQueueStorageKVClient):
         if non_tensor_keys:
             self._batch_put_bytes(non_tensor_keys, non_tensor_values)
 
+        _t_done = time.perf_counter()
+        print(
+            f"[TQ-TIMING] mooncake::put n={len(keys)}: "
+            f"classify={_t_classify1-_t_classify0:.4f}s  total={_t_done-_t_classify0:.4f}s",
+            flush=True,
+        )
         return None
 
     def _batch_put_tensors(self, keys: list[str], tensors: list[Tensor]):
+        _t_loop_total0 = time.perf_counter()
+        _overhead_s = 0.0
+        _rdma_s = 0.0
+        _n_batches = 0
         for i in range(0, len(keys), BATCH_SIZE_LIMIT):
+            _t_oh0 = time.perf_counter()
             batch_keys = keys[i : i + BATCH_SIZE_LIMIT]
             batch_tensors = tensors[i : i + BATCH_SIZE_LIMIT]
+            data_gb = sum(t.numel() * t.element_size() for t in batch_tensors) / (1024**3)
+            _t_oh1 = time.perf_counter()
 
+            _t0 = time.perf_counter()
             results = self._store.batch_put_tensor(batch_keys, batch_tensors)
+            _t1 = time.perf_counter()
+            print(
+                f"[TQ-TIMING] mooncake::batch_put_tensor n={len(batch_keys)} "
+                f"data={data_gb:.4f}GB  rdma={_t1-_t0:.4f}s  bw={data_gb*8/(_t1-_t0):.2f}Gb/s",
+                flush=True,
+            )
+
+            _t_val0 = time.perf_counter()
             if not all(r == 0 for r in results):
                 failed_indices = [j for j, r in enumerate(results) if r != 0]
                 error_codes = [results[j] for j in failed_indices]
                 raise RuntimeError(
                     f"batch_put_tensor failed for indices {failed_indices} with error codes: {error_codes}"
                 )
+            _t_val1 = time.perf_counter()
+
+            _overhead_s += (_t_oh1 - _t_oh0) + (_t_val1 - _t_val0)
+            _rdma_s += (_t1 - _t0)
+            _n_batches += 1
+        _t_loop_total1 = time.perf_counter()
+        print(
+            f"[TQ-TIMING] mooncake::put_loop n={len(keys)} batches={_n_batches}: "
+            f"rdma_total={_rdma_s:.4f}s  py_overhead={_overhead_s:.4f}s  "
+            f"loop_total={_t_loop_total1-_t_loop_total0:.4f}s",
+            flush=True,
+        )
+
+    def _batch_put_tensors_gdr(self, keys: list[str], tensors: list[Tensor]):
+        """Put GPU tensors via GDR using a pre-registered staging buffer.
+
+        Tensors are D2D-copied into a contiguous GPU staging buffer that was
+        registered with RDMA once at init.  This eliminates the per-tensor
+        ``register_buffer`` / ``unregister_buffer`` overhead (~6 ms each for
+        GPU memory through nvidia_peermem).
+        """
+        _t_loop_total0 = time.perf_counter()
+        _rdma_s = 0.0
+        _d2d_s = 0.0
+        _n_batches = 0
+        staging_ptr = self._gdr_staging_ptr
+        staging_cap = self._gdr_staging_size
+        meta_ptr = self._gdr_meta_ptr
+
+        idx = 0
+        while idx < len(keys):
+            # Build sub-batch bounded by BATCH_SIZE_LIMIT *and* staging capacity
+            batch_keys: list[str] = []
+            batch_tensors: list[Tensor] = []
+            used = 0
+            while idx < len(keys) and len(batch_keys) < BATCH_SIZE_LIMIT:
+                sz = tensors[idx].numel() * tensors[idx].element_size()
+                if used + sz > staging_cap:
+                    if not batch_keys:
+                        raise RuntimeError(
+                            f"Single tensor ({sz} bytes) exceeds GDR staging buffer "
+                            f"({staging_cap} bytes). Increase gdr_buffer_size in config."
+                        )
+                    break
+                batch_keys.append(keys[idx])
+                batch_tensors.append(tensors[idx])
+                used += sz
+                idx += 1
+
+            n = len(batch_keys)
+            data_gb = used / (1024**3)
+
+            # D2D copy each tensor into the staging buffer, fill metadata
+            _t_d2d0 = time.perf_counter()
+            all_buffer_ptrs: list[list[int]] = []
+            all_sizes: list[list[int]] = []
+            offset = 0
+            for j, tensor in enumerate(batch_tensors):
+                meta_offset = j * TENSOR_METADATA_SIZE
+                self._gdr_meta_buf[meta_offset : meta_offset + TENSOR_METADATA_SIZE] = (
+                    _pack_tensor_metadata(tensor.dtype, tuple(tensor.shape))
+                )
+                data_size = tensor.numel() * tensor.element_size()
+                _cuda_d2d_copy(staging_ptr + offset, tensor.data_ptr(), data_size)
+
+                all_buffer_ptrs.append([meta_ptr + meta_offset, staging_ptr + offset])
+                all_sizes.append([TENSOR_METADATA_SIZE, data_size])
+                offset += data_size
+            _t_d2d1 = time.perf_counter()
+
+            # RDMA transfer: metadata from CPU, tensor data from GPU staging buf
+            _t0 = time.perf_counter()
+            results = self._store.batch_put_from_multi_buffers(batch_keys, all_buffer_ptrs, all_sizes)
+            _t1 = time.perf_counter()
+
+            if not all(r == 0 for r in results):
+                failed_indices = [j for j, r in enumerate(results) if r != 0]
+                error_codes = [results[j] for j in failed_indices]
+                raise RuntimeError(
+                    f"GDR batch_put failed for indices {failed_indices} with error codes: {error_codes}"
+                )
+
+            print(
+                f"[TQ-TIMING] mooncake::gdr_batch_put n={n} "
+                f"data={data_gb:.4f}GB  d2d={_t_d2d1-_t_d2d0:.4f}s  "
+                f"rdma={_t1-_t0:.4f}s  bw={data_gb*8/(_t1-_t0):.2f}Gb/s",
+                flush=True,
+            )
+            _rdma_s += _t1 - _t0
+            _d2d_s += _t_d2d1 - _t_d2d0
+            _n_batches += 1
+
+        _t_loop_total1 = time.perf_counter()
+        print(
+            f"[TQ-TIMING] mooncake::gdr_put_loop n={len(keys)} batches={_n_batches}: "
+            f"rdma_total={_rdma_s:.4f}s  d2d_total={_d2d_s:.4f}s  "
+            f"loop_total={_t_loop_total1-_t_loop_total0:.4f}s",
+            flush=True,
+        )
 
     def _batch_put_bytes(self, keys: list[str], values: list[bytes]):
         for i in range(0, len(keys), BATCH_SIZE_LIMIT):
@@ -174,6 +414,7 @@ class MooncakeStoreClient(TransferQueueStorageKVClient):
         if not (len(keys) == len(shapes) == len(dtypes)):
             raise ValueError("Lengths of keys, shapes, dtypes must match")
 
+        _t_classify0 = time.perf_counter()
         tensor_indices = []
         non_tensor_indices = []
 
@@ -184,15 +425,23 @@ class MooncakeStoreClient(TransferQueueStorageKVClient):
                 non_tensor_indices.append(i)
 
         results = [None] * len(keys)
+        _t_classify1 = time.perf_counter()
 
         if tensor_indices:
+            _t_scatter0 = time.perf_counter()
             tensor_keys = [keys[i] for i in tensor_indices]
             tensor_shapes = [shapes[i] for i in tensor_indices]
             tensor_dtypes = [dtypes[i] for i in tensor_indices]
-            tensor_results = self._batch_get_tensors(tensor_keys, tensor_shapes, tensor_dtypes)
+            _t_scatter1 = time.perf_counter()
+            if self._use_gdr:
+                tensor_results = self._batch_get_tensors_gdr(tensor_keys, tensor_shapes, tensor_dtypes)
+            else:
+                tensor_results = self._batch_get_tensors(tensor_keys, tensor_shapes, tensor_dtypes)
+            _t_gather0 = time.perf_counter()
             # TODO: optimize these for loops
             for idx, tensor in zip(tensor_indices, tensor_results, strict=True):
                 results[idx] = tensor
+            _t_gather1 = time.perf_counter()
 
         if non_tensor_indices:
             non_tensor_keys = [keys[i] for i in non_tensor_indices]
@@ -200,18 +449,47 @@ class MooncakeStoreClient(TransferQueueStorageKVClient):
             for idx, data in zip(non_tensor_indices, non_tensor_results, strict=True):
                 results[idx] = pickle.loads(data)
 
+        _t_done = time.perf_counter()
+        _scatter = (_t_scatter1 - _t_scatter0) if tensor_indices else 0
+        _gather = (_t_gather1 - _t_gather0) if tensor_indices else 0
+        print(
+            f"[TQ-TIMING] mooncake::get n={len(keys)}: "
+            f"classify={_t_classify1-_t_classify0:.4f}s  scatter={_scatter:.4f}s  "
+            f"gather={_gather:.4f}s  total={_t_done-_t_classify0:.4f}s",
+            flush=True,
+        )
         return results
 
     def _batch_get_tensors(self, keys: list[str], shapes: list, dtypes: list) -> list[Tensor]:
         tensors = [None] * len(keys)
+        _t_loop_total0 = time.perf_counter()
+        _overhead_s = 0.0
+        _rdma_s = 0.0
+        _n_batches = 0
 
         for i in range(0, len(keys), BATCH_SIZE_LIMIT):
+            _t_oh0 = time.perf_counter()
             batch_keys = keys[i : i + BATCH_SIZE_LIMIT]
             batch_shapes = shapes[i : i + BATCH_SIZE_LIMIT]
             batch_dtypes = dtypes[i : i + BATCH_SIZE_LIMIT]
+            dtype_sizes = {torch.float32: 4, torch.float16: 2, torch.bfloat16: 2, torch.int64: 8, torch.int32: 4}
+            data_gb = sum(
+                (torch.Size(s).numel() * dtype_sizes.get(d, 4))
+                for s, d in zip(batch_shapes, batch_dtypes)
+                if d is not None
+            ) / (1024**3)
+            _t_oh1 = time.perf_counter()
 
+            _t0 = time.perf_counter()
             batch_results = self._store.batch_get_tensor(batch_keys)
+            _t1 = time.perf_counter()
+            print(
+                f"[TQ-TIMING] mooncake::batch_get_tensor n={len(batch_keys)} "
+                f"data={data_gb:.4f}GB  rdma={_t1-_t0:.4f}s  bw={data_gb*8/(_t1-_t0):.2f}Gb/s",
+                flush=True,
+            )
 
+            _t_val0 = time.perf_counter()
             if len(batch_results) != len(batch_keys):
                 raise RuntimeError(f"batch_get_tensor returned {len(batch_results)} items, expected {len(batch_keys)}")
 
@@ -227,7 +505,114 @@ class MooncakeStoreClient(TransferQueueStorageKVClient):
                         f"Dtype mismatch for key '{batch_keys[j]}': expected {dtype}, got {tensor.dtype}"
                     )
                 tensors[i + j] = tensor
+            _t_val1 = time.perf_counter()
 
+            _overhead_s += (_t_oh1 - _t_oh0) + (_t_val1 - _t_val0)
+            _rdma_s += (_t1 - _t0)
+            _n_batches += 1
+
+        _t_loop_total1 = time.perf_counter()
+        print(
+            f"[TQ-TIMING] mooncake::get_loop n={len(keys)} batches={_n_batches}: "
+            f"rdma_total={_rdma_s:.4f}s  py_overhead={_overhead_s:.4f}s  "
+            f"loop_total={_t_loop_total1-_t_loop_total0:.4f}s",
+            flush=True,
+        )
+        return tensors
+
+    def _batch_get_tensors_gdr(self, keys: list[str], shapes: list, dtypes: list) -> list[Tensor]:
+        """Get tensors into GPU memory via GDR using a pre-registered staging buffer.
+
+        RDMA reads land in the staging buffer, then D2D-copied to individual
+        output tensors.  Same registration-avoidance strategy as the PUT path.
+        """
+        device = self._gdr_target_device or f"cuda:{torch.cuda.current_device()}"
+        tensors: list[Optional[Tensor]] = [None] * len(keys)
+        _t_loop_total0 = time.perf_counter()
+        _rdma_s = 0.0
+        _d2d_s = 0.0
+        _n_batches = 0
+        staging_ptr = self._gdr_staging_ptr
+        staging_cap = self._gdr_staging_size
+        meta_ptr = self._gdr_meta_ptr
+
+        idx = 0
+        while idx < len(keys):
+            batch_start = idx
+            batch_keys: list[str] = []
+            batch_shapes: list = []
+            batch_dtypes: list = []
+            used = 0
+            while idx < len(keys) and len(batch_keys) < BATCH_SIZE_LIMIT:
+                s, d = shapes[idx], dtypes[idx]
+                sz = torch.Size(s).numel() * _DTYPE_ELEMENT_SIZE[d]
+                if used + sz > staging_cap:
+                    if not batch_keys:
+                        raise RuntimeError(
+                            f"Single tensor ({sz} bytes) exceeds GDR staging buffer "
+                            f"({staging_cap} bytes). Increase gdr_buffer_size in config."
+                        )
+                    break
+                batch_keys.append(keys[idx])
+                batch_shapes.append(s)
+                batch_dtypes.append(d)
+                used += sz
+                idx += 1
+
+            n = len(batch_keys)
+            data_gb = used / (1024**3)
+
+            # Map each tensor's region in the staging buffer
+            all_buffer_ptrs: list[list[int]] = []
+            all_sizes: list[list[int]] = []
+            tensor_regions: list[tuple[int, int]] = []  # (offset, data_size)
+            offset = 0
+            for j, (s, d) in enumerate(zip(batch_shapes, batch_dtypes)):
+                meta_offset = j * TENSOR_METADATA_SIZE
+                data_size = torch.Size(s).numel() * _DTYPE_ELEMENT_SIZE[d]
+                all_buffer_ptrs.append([meta_ptr + meta_offset, staging_ptr + offset])
+                all_sizes.append([TENSOR_METADATA_SIZE, data_size])
+                tensor_regions.append((offset, data_size))
+                offset += data_size
+
+            # RDMA transfer: metadata → CPU, tensor data → GPU staging buffer
+            _t0 = time.perf_counter()
+            results = self._store.batch_get_into_multi_buffers(batch_keys, all_buffer_ptrs, all_sizes)
+            _t1 = time.perf_counter()
+
+            if any(r < 0 for r in results):
+                failed_indices = [j for j, r in enumerate(results) if r < 0]
+                error_codes = [results[j] for j in failed_indices]
+                raise RuntimeError(
+                    f"GDR batch_get failed for indices {failed_indices} with error codes: {error_codes}"
+                )
+
+            # D2D copy from staging buffer to individual output tensors
+            _t_d2d0 = time.perf_counter()
+            for j, (s, d) in enumerate(zip(batch_shapes, batch_dtypes)):
+                t = torch.empty(s, dtype=d, device=device)
+                buf_offset, data_size = tensor_regions[j]
+                _cuda_d2d_copy(t.data_ptr(), staging_ptr + buf_offset, data_size)
+                tensors[batch_start + j] = t
+            _t_d2d1 = time.perf_counter()
+
+            print(
+                f"[TQ-TIMING] mooncake::gdr_batch_get n={n} "
+                f"data={data_gb:.4f}GB  rdma={_t1-_t0:.4f}s  "
+                f"d2d={_t_d2d1-_t_d2d0:.4f}s  bw={data_gb*8/(_t1-_t0):.2f}Gb/s",
+                flush=True,
+            )
+            _rdma_s += _t1 - _t0
+            _d2d_s += _t_d2d1 - _t_d2d0
+            _n_batches += 1
+
+        _t_loop_total1 = time.perf_counter()
+        print(
+            f"[TQ-TIMING] mooncake::gdr_get_loop n={len(keys)} batches={_n_batches}: "
+            f"rdma_total={_rdma_s:.4f}s  d2d_total={_d2d_s:.4f}s  "
+            f"loop_total={_t_loop_total1-_t_loop_total0:.4f}s",
+            flush=True,
+        )
         return tensors
 
     def _batch_get_bytes(self, keys: list[str]) -> list[bytes]:
@@ -264,5 +649,13 @@ class MooncakeStoreClient(TransferQueueStorageKVClient):
     def close(self):
         """Closes MooncakeStore."""
         if self._store:
+            if self._use_gdr:
+                if self._gdr_staging_ptr:
+                    self._store.unregister_buffer(self._gdr_staging_ptr)
+                    self._gdr_staging_ptr = 0
+                if self._gdr_meta_ptr:
+                    self._store.unregister_buffer(self._gdr_meta_ptr)
+                    self._gdr_meta_ptr = 0
+                self._gdr_staging_buf = None
             self._store.close()
             self._store = None


### PR DESCRIPTION
## Summary
- Add GDR (GPU Direct RDMA) path for MooncakeStore, bypassing CPU-mediated D2H/H2D copies
- [TO OPTIMIZE] Use a pre-registered GPU staging buffer to avoid per-tensor `ibv_reg_mr` overhead (~6ms each)
- **4.3x PUT / 3.5x GET throughput improvement** on 7.5GB GPU tensor transfers (2-node RDMA)

## The Issue of GDR

RDMA requires all memory regions to be registered via `ibv_reg_mr` before transfer. This applies to both CPU and GPU memory, but the cost is vastly different:

| | CPU memory | GPU memory (nvidia_peermem) |
|--|-----------|---------------------------|
| `ibv_reg_mr` cost | ~us | **~6ms** |
| Reason | pin pages + page table mapping | must call into NVIDIA driver for BAR1 physical address mapping |

In the current baseline, mooncake registers each tensor individually on every transfer:

```
Baseline: for each tensor → ibv_reg_mr → RDMA → ibv_dereg_mr
          500 GPU tensors × 6ms = ~3s registration overhead alone
```

This makes GPU tensor transfer significantly slower than expected from the raw RDMA bandwidth.

## What We Did

We implemented a **staging buffer prototype** to validate GDR performance:

```
Baseline:
  GPU Tensor → mooncake (per-tensor ibv_reg_mr + D2H + CPU RDMA) → Remote

GDR prototype:
  GPU Tensor → D2D copy → [Staging Buffer] → GDR RDMA → Remote
                           (ibv_reg_mr once)
```

One large GPU buffer is allocated and registered once at init. All tensors are D2D-copied into this buffer before RDMA transfer. This amortizes the `ibv_reg_mr` cost to a one-time operation.

## Benchmark

2-node RDMA cluster (RoCE v2), `nvidia_peermem` loaded.

### Throughput

| Scale | Data | Mode | PUT (Gb/s) | GET (Gb/s) | Speedup |
|-------|------|------|-----------|-----------|---------|
| medium | 7.5 GB | Baseline | 15.8 | 16.0 | — |
| medium | 7.5 GB | **GDR** | **67.9** | **55.6** | **PUT 4.3x, GET 3.5x** |
| small | 0.28 GB | Baseline | 6.4 | 12.3 | — |
| small | 0.28 GB | **GDR** | **14.2** | **16.3** | **PUT 2.2x, GET 1.3x** |

### Step-Level Breakdown (7.5 GB)

| Path | Baseline | GDR |
|------|---------|-----|
| PUT wall time | ~3.3s (D2H ~1.65s + CPU RDMA ~1.4s) | ~0.96s (D2D ~0.36s + GDR RDMA ~0.40s) |
| GET wall time | ~4.5s (CPU RDMA ~2.5s + H2D ~1.6s) | ~1.1s (GDR RDMA ~0.36s + D2D ~0.5s) |

<img width="2384" height="1504" alt="gdr_breakdown_comparison" src="https://github.com/user-attachments/assets/65fce73d-893b-4c7f-83a9-3962efb56e36" />