### PR TITLE
[fix] Increase `mooncake_master` client_ttl to mitigate client heartbeat timeout 

### DIFF
--- a/transfer_queue/interface.py
+++ b/transfer_queue/interface.py
@@ -145,6 +145,7 @@ def _maybe_create_tq_storage(conf: DictConfig) -> DictConfig:
 
                 cmd = [
                     "mooncake_master",
+                    "-client_ttl=30",
                     "-default_kv_lease_ttl=999999",
                     "-default_kv_soft_pin_ttl=999999",
                     "--eviction_high_watermark_ratio=1.0",


### PR DESCRIPTION
## Background

During the integration of MooncakeStore with verl, we encountered unexpected connection errors and segment unregistrations. After investigation, we identified that the issue is caused by the starvation or stalling of Mooncake's heartbeat mechanism.

Although Mooncake's heartbeat logic is implemented in C++ and theoretically should not be affected by Python-level concurrency models (such as ray, asyncio, or multi-threading/coroutines), our analysis indicates that the blockage likely occurs at the C++/Python interface layer (to be further verified). When the Python side is heavily loaded, it stalls the interface, which inadvertently blocks the underlying C++ heartbeat threads.

<img width="2127" height="787" alt="c5ad341a2bd0589bc070a0b3b1979da4" src="https://github.com/user-attachments/assets/25d2c0ce-48ce-43b0-9ada-0677cd6ee8eb" />
<img width="2266" height="1135" alt="081875fe360b39aa1c61c62821e20e08" src="https://github.com/user-attachments/assets/b0032356-a125-4cd2-8b14-cd283f3cfd59" />


## Solution

Increase `-client_ttl` from 10 to 30 during initializing `mooncake_master` process.
