### PR TITLE
[fix,refactor] Isolate `notify_data_update` ZMQ I/O into a dedicated background asyncio loop

### DIFF
--- a/transfer_queue/storage/managers/base.py
+++ b/transfer_queue/storage/managers/base.py
@@ -71,7 +71,7 @@ class StorageManager(ABC):
         # Handshake socket is sync (used only during initialization)
         self.controller_handshake_socket: zmq.Socket | None = None
 
-        self.zmq_context: zmq.asyncio.Context | None = None
+        self.zmq_context = zmq.asyncio.Context()
         self._connect_to_controller()
 
         # Dedicated asyncio loop for ZMQ notify traffic, isolated from the caller's loop
@@ -109,9 +109,6 @@ class StorageManager(ABC):
                 self.controller_handshake_socket.close(linger=0)
                 self.controller_handshake_socket = None
             sync_zmq_context.term()
-
-            # create async context for data status update
-            self.zmq_context = zmq.asyncio.Context()
 
         except Exception as e:
             logger.error(f"Failed to connect to controller: {e}")

--- a/transfer_queue/storage/managers/base.py
+++ b/transfer_queue/storage/managers/base.py
@@ -54,6 +54,7 @@ def _run_notify_loop(notify_loop: asyncio.AbstractEventLoop) -> None:
     finally:
         notify_loop.close()
 
+
 LIMIT_THREADS_PER_MANAGER_IN_DRIVER = 8
 LIMIT_THREADS_PER_MANAGER_IN_RAY_ACTOR = 4
 
@@ -126,8 +127,7 @@ class StorageManager(ABC):
             self._notify_sock.setsockopt(zmq.LINGER, 0)
             self._notify_sock.connect(self.controller_info.to_addr("request_handle_socket"))
             logger.debug(
-                f"[{self.storage_manager_id}]: Notify ZMQ socket connected "
-                f"to controller {self.controller_info.id}."
+                f"[{self.storage_manager_id}]: Notify ZMQ socket connected to controller {self.controller_info.id}."
             )
         except Exception as e:
             logger.critical(f"[{self.storage_manager_id}]: Failed to initialize notify ZMQ: {e}")

--- a/transfer_queue/storage/managers/base.py
+++ b/transfer_queue/storage/managers/base.py
@@ -16,6 +16,7 @@
 import asyncio
 import itertools
 import os
+import threading
 import time
 import weakref
 from abc import ABC, abstractmethod
@@ -45,6 +46,14 @@ TQ_STORAGE_HANDSHAKE_RETRY_INTERVAL = int(os.environ.get("TQ_STORAGE_HANDSHAKE_R
 TQ_STORAGE_HANDSHAKE_MAX_RETRIES = int(os.environ.get("TQ_STORAGE_HANDSHAKE_MAX_RETRIES", 3))
 TQ_DATA_UPDATE_RESPONSE_TIMEOUT = int(os.environ.get("TQ_DATA_UPDATE_RESPONSE_TIMEOUT", 30))
 
+
+def _run_notify_loop(notify_loop: asyncio.AbstractEventLoop) -> None:
+    asyncio.set_event_loop(notify_loop)
+    try:
+        notify_loop.run_forever()
+    finally:
+        notify_loop.close()
+
 LIMIT_THREADS_PER_MANAGER_IN_DRIVER = 8
 LIMIT_THREADS_PER_MANAGER_IN_RAY_ACTOR = 4
 
@@ -61,41 +70,70 @@ class StorageManager(ABC):
         # Handshake socket is sync (used only during initialization)
         self.controller_handshake_socket: zmq.Socket | None = None
 
-        self.zmq_context: zmq.asyncio.Context | None = None
         self._connect_to_controller()
 
+        # Dedicated asyncio loop for ZMQ notify traffic, isolated from the caller's loop
+        self._notify_loop = asyncio.new_event_loop()
+        self._notify_thread = threading.Thread(
+            target=_run_notify_loop,
+            args=(self._notify_loop,),
+            daemon=True,
+            name=f"{self.storage_manager_id}-notify_data_status_loop",
+        )
+        self._notify_thread.start()
+
+        self._notify_zmq_ctx: zmq.asyncio.Context | None = None
+        self._notify_sock: zmq.asyncio.Socket | None = None
+        self._notify_lock = asyncio.Lock()
+        notify_sock_ready = threading.Event()
+        asyncio.run_coroutine_threadsafe(self._init_notify_zmq(notify_sock_ready), self._notify_loop)
+        notify_sock_ready.wait()
+
     def _connect_to_controller(self) -> None:
-        """Initialize ZMQ sockets between storage unit and controller for handshake."""
+        """Establish initial connection to the controller via a blocking handshake."""
         if not isinstance(self.controller_info, ZMQServerInfo):
             raise ValueError(f"controller_info should be ZMQServerInfo, but got {type(self.controller_info)}")
 
+        sync_zmq_context = zmq.Context()
         try:
-            # Create a synchronous context for handshake (blocking operation)
-            sync_zmq_context = zmq.Context()
-
-            # create zmq socket for handshake (sync, for initial connection)
             self.controller_handshake_socket = create_zmq_socket(
                 ctx=sync_zmq_context,
                 socket_type=zmq.DEALER,
                 ip=self.controller_info.ip,
                 identity=f"{self.storage_manager_id}-controller_handshake_socket-{uuid4().hex[:8]}".encode(),
             )
-
-            # do handshake with controller using sync socket
             self._do_handshake_with_controller()
-
-            # close the sync handshake socket and context after handshake
+        except Exception as e:
+            logger.error(f"Failed to connect to controller: {e}")
+            raise
+        finally:
             if self.controller_handshake_socket and not self.controller_handshake_socket.closed:
                 self.controller_handshake_socket.close(linger=0)
                 self.controller_handshake_socket = None
             sync_zmq_context.term()
 
-            # create async context for data status update
-            self.zmq_context = zmq.asyncio.Context()
-
+    async def _init_notify_zmq(self, notify_sock_ready: threading.Event) -> None:
+        """Create the async ZMQ DEALER socket used for data status notifications."""
+        try:
+            self._notify_zmq_ctx = zmq.asyncio.Context()
+            identity = f"{self.storage_manager_id}-notify-{uuid4().hex[:8]}".encode()
+            self._notify_sock = create_zmq_socket(
+                ctx=self._notify_zmq_ctx,
+                socket_type=zmq.DEALER,
+                ip=self.controller_info.ip,
+                identity=identity,
+            )
+            self._notify_sock.setsockopt(zmq.LINGER, 0)
+            self._notify_sock.connect(self.controller_info.to_addr("request_handle_socket"))
+            logger.debug(
+                f"[{self.storage_manager_id}]: Notify ZMQ socket connected "
+                f"to controller {self.controller_info.id}."
+            )
         except Exception as e:
-            logger.error(f"Failed to connect to controller: {e}")
+            logger.critical(f"[{self.storage_manager_id}]: Failed to initialize notify ZMQ: {e}")
             raise
+        finally:
+            notify_sock_ready.set()
 
     def _do_handshake_with_controller(self) -> None:
         """Handshake with controller to establish connection with retransmission mechanism."""
@@ -205,54 +243,47 @@ class StorageManager(ABC):
             logger.warning(f"No controller connected for storage manager {self.storage_manager_id}")
             return
 
-        # create dynamic socket
-        identity = f"{self.storage_manager_id}-data_update-{uuid4().hex[:8]}".encode()
-        sock = create_zmq_socket(self.zmq_context, zmq.DEALER, self.controller_info.ip, identity)
+        normalized_field_schema = {}
+        for field_name, field in field_schema.items():
+            field_copy = field.copy()
+            per_sample_shapes = field_copy.get("per_sample_shapes", None)
+            if isinstance(per_sample_shapes, list | tuple):
+                if len(per_sample_shapes) != len(global_indexes):
+                    raise ValueError(
+                        f"per_sample_shapes length ({len(per_sample_shapes)}) does not match "
+                        f"number of global_indexes ({len(global_indexes)}) for field '{field_name}'; "
+                        f"skipping per_sample_shapes normalization."
+                    )
+                field_copy["per_sample_shapes"] = {
+                    global_indexes[i]: per_sample_shapes[i] for i in range(len(global_indexes))
+                }
+            normalized_field_schema[field_name] = field_copy
 
-        try:
-            sock.connect(self.controller_info.to_addr("request_handle_socket"))
+        request_msg = ZMQMessage.create(
+            request_type=ZMQRequestType.NOTIFY_DATA_UPDATE,  # type: ignore[arg-type]
+            sender_id=self.storage_manager_id,
+            body={
+                "partition_id": partition_id,
+                "global_indexes": global_indexes,
+                "field_schema": normalized_field_schema,
+                "custom_backend_meta": custom_backend_meta,
+            },
+        ).serialize()
 
-            normalized_field_schema = {}
-            for field_name, field in field_schema.items():
-                # Work on a shallow copy to avoid mutating caller-provided schema
-                field_copy = field.copy()
-                per_sample_shapes = field_copy.get("per_sample_shapes", None)
-                if isinstance(per_sample_shapes, list | tuple):
-                    if len(per_sample_shapes) != len(global_indexes):
-                        raise ValueError(
-                            f"per_sample_shapes length ({len(per_sample_shapes)}) does not match "
-                            f"number of global_indexes ({len(global_indexes)}) for field '{field_name}'; "
-                            f"skipping per_sample_shapes normalization."
-                        )
-                    else:
-                        field_copy["per_sample_shapes"] = {
-                            global_indexes[i]: per_sample_shapes[i] for i in range(len(global_indexes))
-                        }
+        thread_future = asyncio.run_coroutine_threadsafe(
+            self._notify_and_wait(request_msg),
+            self._notify_loop,
+        )
+        await asyncio.wrap_future(thread_future)
 
-                normalized_field_schema[field_name] = field_copy
+    async def _notify_and_wait(self, request_msg: list) -> None:
+        """Send a data status notification to the controller and block until ACK is received."""
+        assert self._notify_sock is not None
 
-            # convert per_sample_shapes into dict
-            for field in field_schema.values():
-                per_sample_shapes = field.get("per_sample_shapes", None)
-                if per_sample_shapes:
-                    per_sample_shapes = {global_indexes[i]: per_sample_shapes[i] for i in range(len(global_indexes))}
-                    field["per_sample_shapes"] = per_sample_shapes
-
-            request_msg = ZMQMessage.create(
-                request_type=ZMQRequestType.NOTIFY_DATA_UPDATE,  # type: ignore[arg-type]
-                sender_id=self.storage_manager_id,
-                body={
-                    "partition_id": partition_id,
-                    "global_indexes": global_indexes,
-                    "field_schema": normalized_field_schema,
-                    "custom_backend_meta": custom_backend_meta,
-                },
-            ).serialize()
-
-            await sock.send_multipart(request_msg)
+        async with self._notify_lock:
+            await self._notify_sock.send_multipart(request_msg)
             logger.debug(
-                f"[{self.storage_manager_id}]: Send data status update request "
-                f"from storage manager id #{self.storage_manager_id} "
+                f"[{self.storage_manager_id}]: Sent data status update request "
                 f"to controller id #{self.controller_info.id} successfully."
             )
 
@@ -262,7 +293,10 @@ class StorageManager(ABC):
             while not response_received and timeout > 0:
                 try:
                     poll_interval = min(TQ_STORAGE_POLLER_TIMEOUT, timeout)
-                    messages = await asyncio.wait_for(sock.recv_multipart(copy=False), timeout=poll_interval)
+                    messages = await asyncio.wait_for(
+                        self._notify_sock.recv_multipart(copy=False),
+                        timeout=poll_interval,
+                    )
                     response_msg = ZMQMessage.deserialize(messages)
 
                     if response_msg.request_type == ZMQRequestType.NOTIFY_DATA_UPDATE_ACK:  # type: ignore[arg-type]
@@ -271,32 +305,15 @@ class StorageManager(ABC):
                             f"[{self.storage_manager_id}]: Get data status update ACK response "
                             f"from controller id #{response_msg.sender_id} successfully."
                         )
+                        break
                 except asyncio.TimeoutError:
                     timeout -= poll_interval
-                except Exception as e:
-                    logger.warning(f"[{self.storage_manager_id}]: Error receiving response: {e}")
-                    break
 
             if not response_received:
-                logger.error(f"[{self.storage_manager_id}]: Did not receive data status update ACK.")
-
-        except Exception as e:
-            logger.error(f"[{self.storage_manager_id}]: Error during notify_data_update: {e}")
-            try:
-                error_msg = ZMQMessage.create(
-                    request_type=ZMQRequestType.NOTIFY_DATA_UPDATE_ERROR,  # type: ignore[arg-type]
-                    sender_id=self.storage_manager_id,
-                    body={"message": f"Failed to notify: {str(e)}"},
-                ).serialize()
-                await sock.send_multipart(error_msg)
-            except Exception:
-                pass
-        finally:
-            try:
-                if not sock.closed:
-                    sock.close(linger=-1)
-            except Exception:
-                pass
+                raise TimeoutError(
+                    f"[{self.storage_manager_id}]: Timeout waiting for data status update ACK "
+                    f"from controller after {TQ_DATA_UPDATE_RESPONSE_TIMEOUT}s."
+                )
 
     @abstractmethod
     async def put_data(
@@ -344,8 +361,7 @@ class StorageManager(ABC):
         raise NotImplementedError("Subclasses must implement clear_data")
 
     def close(self) -> None:
-        """Close all ZMQ sockets and context to prevent resource leaks."""
-        # Close handshake socket if it exists
+        """Close all ZMQ sockets/contexts and stop the notify loop."""
         if self.controller_handshake_socket:
             try:
                 if not self.controller_handshake_socket.closed:
@@ -353,8 +369,24 @@ class StorageManager(ABC):
             except Exception as e:
                 logger.error(f"[{self.storage_manager_id}]: Error closing controller_handshake_socket: {str(e)}")
 
-        if self.zmq_context:
-            self.zmq_context.term()
+        if not hasattr(self, "_notify_loop") or not self._notify_loop.is_running():
+            return
+
+        async def _cleanup() -> None:
+            if self._notify_sock and not self._notify_sock.closed:
+                self._notify_sock.close()
+            if self._notify_zmq_ctx:
+                self._notify_zmq_ctx.term()
+
+        future = asyncio.run_coroutine_threadsafe(_cleanup(), self._notify_loop)
+        try:
+            future.result(timeout=5)
+        except Exception as e:
+            logger.error(f"[{self.storage_manager_id}]: Error closing notify ZMQ: {e}")
+
+        self._notify_loop.call_soon_threadsafe(self._notify_loop.stop)
+        self._notify_thread.join(timeout=5)
+        logger.debug(f"[{self.storage_manager_id}]: Notify ZMQ thread shut down.")
 
     def __del__(self):
         """Destructor to ensure resources are cleaned up."""

--- a/transfer_queue/storage/managers/base.py
+++ b/transfer_queue/storage/managers/base.py
@@ -67,11 +67,11 @@ class StorageManager(ABC):
         self.storage_manager_id = f"TQ_STORAGE_{uuid4().hex[:8]}"
         self.config = config
         self.controller_info = controller_info
-        self.zmq_ctx = zmq.asyncio.Context()
 
         # Handshake socket is sync (used only during initialization)
         self.controller_handshake_socket: zmq.Socket | None = None
 
+        self.zmq_context: zmq.asyncio.Context | None = None
         self._connect_to_controller()
 
         # Dedicated asyncio loop for ZMQ notify traffic, isolated from the caller's loop
@@ -109,6 +109,9 @@ class StorageManager(ABC):
                 self.controller_handshake_socket.close(linger=0)
                 self.controller_handshake_socket = None
             sync_zmq_context.term()
+
+            # create async context for data status update
+            self.zmq_context = zmq.asyncio.Context()
 
         except Exception as e:
             logger.error(f"Failed to connect to controller: {e}")
@@ -258,7 +261,7 @@ class StorageManager(ABC):
         """Send a data status notification to the controller and block until ACK is received."""
         identity = f"{self.storage_manager_id}-notify-{uuid4().hex[:8]}".encode()
         sock = create_zmq_socket(
-            ctx=self.zmq_ctx, socket_type=zmq.DEALER, ip=self.controller_info.ip, identity=identity
+            ctx=self.zmq_context, socket_type=zmq.DEALER, ip=self.controller_info.ip, identity=identity
         )
         sock.setsockopt(zmq.LINGER, 0)
         sock.connect(self.controller_info.to_addr("request_handle_socket"))
@@ -301,7 +304,11 @@ class StorageManager(ABC):
                     f"from controller after {TQ_DATA_UPDATE_RESPONSE_TIMEOUT}s."
                 )
         finally:
-            sock.close()
+            try:
+                if not sock.closed:
+                    sock.close(linger=-1)
+            except Exception:
+                pass
 
     @abstractmethod
     async def put_data(
@@ -363,7 +370,7 @@ class StorageManager(ABC):
         self._notify_loop.call_soon_threadsafe(self._notify_loop.stop)
         self._notify_thread.join(timeout=5)
 
-        self.zmq_ctx.term()
+        self.zmq_context.term()
 
         logger.debug(f"[{self.storage_manager_id}]: Notify ZMQ thread shut down.")
 

--- a/transfer_queue/storage/managers/base.py
+++ b/transfer_queue/storage/managers/base.py
@@ -74,6 +74,18 @@ class StorageManager(ABC):
         self._connect_to_controller()
 
         # Dedicated asyncio loop for ZMQ notify traffic, isolated from the caller's loop
+        self._notify_zmq_ctx = zmq.asyncio.Context()
+        identity = f"{self.storage_manager_id}-notify-{uuid4().hex[:8]}".encode()
+        self._notify_sock = create_zmq_socket(
+            ctx=self._notify_zmq_ctx,
+            socket_type=zmq.DEALER,
+            ip=self.controller_info.ip,
+            identity=identity,
+        )
+        self._notify_sock.setsockopt(zmq.LINGER, 0)
+        self._notify_sock.connect(self.controller_info.to_addr("request_handle_socket"))
+
+        self._notify_lock = asyncio.Lock()
         self._notify_loop = asyncio.new_event_loop()
         self._notify_thread = threading.Thread(
             target=_run_notify_loop,
@@ -82,13 +94,6 @@ class StorageManager(ABC):
             name=f"{self.storage_manager_id}-notify_data_status_loop",
         )
         self._notify_thread.start()
-
-        self._notify_zmq_ctx: zmq.asyncio.Context | None = None
-        self._notify_sock: zmq.asyncio.Socket | None = None
-        self._notify_lock = asyncio.Lock()
-        notify_sock_ready = threading.Event()
-        asyncio.run_coroutine_threadsafe(self._init_notify_zmq(notify_sock_ready), self._notify_loop)
-        notify_sock_ready.wait()
 
     def _connect_to_controller(self) -> None:
         """Establish initial connection to the controller via a blocking handshake."""
@@ -112,28 +117,6 @@ class StorageManager(ABC):
                 self.controller_handshake_socket.close(linger=0)
                 self.controller_handshake_socket = None
             sync_zmq_context.term()
-
-    async def _init_notify_zmq(self, notify_sock_ready: threading.Event) -> None:
-        """Create the async ZMQ DEALER socket used for data status notifications."""
-        try:
-            self._notify_zmq_ctx = zmq.asyncio.Context()
-            identity = f"{self.storage_manager_id}-notify-{uuid4().hex[:8]}".encode()
-            self._notify_sock = create_zmq_socket(
-                ctx=self._notify_zmq_ctx,
-                socket_type=zmq.DEALER,
-                ip=self.controller_info.ip,
-                identity=identity,
-            )
-            self._notify_sock.setsockopt(zmq.LINGER, 0)
-            self._notify_sock.connect(self.controller_info.to_addr("request_handle_socket"))
-            logger.debug(
-                f"[{self.storage_manager_id}]: Notify ZMQ socket connected to controller {self.controller_info.id}."
-            )
-        except Exception as e:
-            logger.critical(f"[{self.storage_manager_id}]: Failed to initialize notify ZMQ: {e}")
-            raise
-        finally:
-            notify_sock_ready.set()
 
     def _do_handshake_with_controller(self) -> None:
         """Handshake with controller to establish connection with retransmission mechanism."""

--- a/transfer_queue/storage/managers/base.py
+++ b/transfer_queue/storage/managers/base.py
@@ -67,6 +67,7 @@ class StorageManager(ABC):
         self.storage_manager_id = f"TQ_STORAGE_{uuid4().hex[:8]}"
         self.config = config
         self.controller_info = controller_info
+        self.zmq_ctx = zmq.asyncio.Context()
 
         # Handshake socket is sync (used only during initialization)
         self.controller_handshake_socket: zmq.Socket | None = None
@@ -84,27 +85,34 @@ class StorageManager(ABC):
         self._notify_thread.start()
 
     def _connect_to_controller(self) -> None:
-        """Establish initial connection to the controller via a blocking handshake."""
+        """Initialize ZMQ sockets between storage unit and controller for handshake."""
         if not isinstance(self.controller_info, ZMQServerInfo):
             raise ValueError(f"controller_info should be ZMQServerInfo, but got {type(self.controller_info)}")
 
-        sync_zmq_context = zmq.Context()
         try:
+            # Create a synchronous context for handshake (blocking operation)
+            sync_zmq_context = zmq.Context()
+
+            # create zmq socket for handshake (sync, for initial connection)
             self.controller_handshake_socket = create_zmq_socket(
                 ctx=sync_zmq_context,
                 socket_type=zmq.DEALER,
                 ip=self.controller_info.ip,
                 identity=f"{self.storage_manager_id}-controller_handshake_socket-{uuid4().hex[:8]}".encode(),
             )
+
+            # do handshake with controller using sync socket
             self._do_handshake_with_controller()
-        except Exception as e:
-            logger.error(f"Failed to connect to controller: {e}")
-            raise
-        finally:
+
+            # close the sync handshake socket and context after handshake
             if self.controller_handshake_socket and not self.controller_handshake_socket.closed:
                 self.controller_handshake_socket.close(linger=0)
                 self.controller_handshake_socket = None
             sync_zmq_context.term()
+
+        except Exception as e:
+            logger.error(f"Failed to connect to controller: {e}")
+            raise
 
     def _do_handshake_with_controller(self) -> None:
         """Handshake with controller to establish connection with retransmission mechanism."""
@@ -222,8 +230,7 @@ class StorageManager(ABC):
                 if len(per_sample_shapes) != len(global_indexes):
                     raise ValueError(
                         f"per_sample_shapes length ({len(per_sample_shapes)}) does not match "
-                        f"number of global_indexes ({len(global_indexes)}) for field '{field_name}'; "
-                        f"skipping per_sample_shapes normalization."
+                        f"number of global_indexes ({len(global_indexes)}) for field '{field_name}'. "
                     )
                 field_copy["per_sample_shapes"] = {
                     global_indexes[i]: per_sample_shapes[i] for i in range(len(global_indexes))
@@ -249,9 +256,10 @@ class StorageManager(ABC):
 
     async def _notify_and_wait(self, request_msg: list) -> None:
         """Send a data status notification to the controller and block until ACK is received."""
-        zmq_ctx = zmq.asyncio.Context()
         identity = f"{self.storage_manager_id}-notify-{uuid4().hex[:8]}".encode()
-        sock = create_zmq_socket(ctx=zmq_ctx, socket_type=zmq.DEALER, ip=self.controller_info.ip, identity=identity)
+        sock = create_zmq_socket(
+            ctx=self.zmq_ctx, socket_type=zmq.DEALER, ip=self.controller_info.ip, identity=identity
+        )
         sock.setsockopt(zmq.LINGER, 0)
         sock.connect(self.controller_info.to_addr("request_handle_socket"))
 
@@ -283,15 +291,17 @@ class StorageManager(ABC):
                         break
                 except asyncio.TimeoutError:
                     timeout -= poll_interval
+                except Exception as e:
+                    logger.warning(f"[{self.storage_manager_id}]: Error receiving response: {e}")
+                    break
 
             if not response_received:
-                raise TimeoutError(
+                logger.error(
                     f"[{self.storage_manager_id}]: Timeout waiting for data status update ACK "
                     f"from controller after {TQ_DATA_UPDATE_RESPONSE_TIMEOUT}s."
                 )
         finally:
             sock.close()
-            zmq_ctx.term()
 
     @abstractmethod
     async def put_data(
@@ -352,6 +362,9 @@ class StorageManager(ABC):
 
         self._notify_loop.call_soon_threadsafe(self._notify_loop.stop)
         self._notify_thread.join(timeout=5)
+
+        self.zmq_ctx.term()
+
         logger.debug(f"[{self.storage_manager_id}]: Notify ZMQ thread shut down.")
 
     def __del__(self):

--- a/transfer_queue/storage/managers/base.py
+++ b/transfer_queue/storage/managers/base.py
@@ -74,18 +74,6 @@ class StorageManager(ABC):
         self._connect_to_controller()
 
         # Dedicated asyncio loop for ZMQ notify traffic, isolated from the caller's loop
-        self._notify_zmq_ctx = zmq.asyncio.Context()
-        identity = f"{self.storage_manager_id}-notify-{uuid4().hex[:8]}".encode()
-        self._notify_sock = create_zmq_socket(
-            ctx=self._notify_zmq_ctx,
-            socket_type=zmq.DEALER,
-            ip=self.controller_info.ip,
-            identity=identity,
-        )
-        self._notify_sock.setsockopt(zmq.LINGER, 0)
-        self._notify_sock.connect(self.controller_info.to_addr("request_handle_socket"))
-
-        self._notify_lock = asyncio.Lock()
         self._notify_loop = asyncio.new_event_loop()
         self._notify_thread = threading.Thread(
             target=_run_notify_loop,
@@ -261,10 +249,14 @@ class StorageManager(ABC):
 
     async def _notify_and_wait(self, request_msg: list) -> None:
         """Send a data status notification to the controller and block until ACK is received."""
-        assert self._notify_sock is not None
+        zmq_ctx = zmq.asyncio.Context()
+        identity = f"{self.storage_manager_id}-notify-{uuid4().hex[:8]}".encode()
+        sock = create_zmq_socket(ctx=zmq_ctx, socket_type=zmq.DEALER, ip=self.controller_info.ip, identity=identity)
+        sock.setsockopt(zmq.LINGER, 0)
+        sock.connect(self.controller_info.to_addr("request_handle_socket"))
 
-        async with self._notify_lock:
-            await self._notify_sock.send_multipart(request_msg)
+        try:
+            await sock.send_multipart(request_msg)
             logger.debug(
                 f"[{self.storage_manager_id}]: Sent data status update request "
                 f"to controller id #{self.controller_info.id} successfully."
@@ -277,7 +269,7 @@ class StorageManager(ABC):
                 try:
                     poll_interval = min(TQ_STORAGE_POLLER_TIMEOUT, timeout)
                     messages = await asyncio.wait_for(
-                        self._notify_sock.recv_multipart(copy=False),
+                        sock.recv_multipart(copy=False),
                         timeout=poll_interval,
                     )
                     response_msg = ZMQMessage.deserialize(messages)
@@ -297,6 +289,9 @@ class StorageManager(ABC):
                     f"[{self.storage_manager_id}]: Timeout waiting for data status update ACK "
                     f"from controller after {TQ_DATA_UPDATE_RESPONSE_TIMEOUT}s."
                 )
+        finally:
+            sock.close()
+            zmq_ctx.term()
 
     @abstractmethod
     async def put_data(
@@ -354,18 +349,6 @@ class StorageManager(ABC):
 
         if not hasattr(self, "_notify_loop") or not self._notify_loop.is_running():
             return
-
-        async def _cleanup() -> None:
-            if self._notify_sock and not self._notify_sock.closed:
-                self._notify_sock.close()
-            if self._notify_zmq_ctx:
-                self._notify_zmq_ctx.term()
-
-        future = asyncio.run_coroutine_threadsafe(_cleanup(), self._notify_loop)
-        try:
-            future.result(timeout=5)
-        except Exception as e:
-            logger.error(f"[{self.storage_manager_id}]: Error closing notify ZMQ: {e}")
 
         self._notify_loop.call_soon_threadsafe(self._notify_loop.stop)
         self._notify_thread.join(timeout=5)

--- a/transfer_queue/storage/managers/base.py
+++ b/transfer_queue/storage/managers/base.py
@@ -303,7 +303,7 @@ class StorageManager(ABC):
         finally:
             try:
                 if not sock.closed:
-                    sock.close(linger=-1)
+                    sock.close(linger=0)
             except Exception:
                 pass
 
@@ -364,11 +364,15 @@ class StorageManager(ABC):
 
         if hasattr(self, "_notify_loop") and self._notify_loop.is_running():
             self._notify_loop.call_soon_threadsafe(self._notify_loop.stop)
-            self._notify_thread.join(timeout=5)
+
+        if hasattr(self, "_notify_thread") and self._notify_thread is not None:
+            self._notify_thread.join(timeout=5.0)
+            if self._notify_thread.is_alive():
+                logger.warning(f"[{self.storage_manager_id}]: Notify ZMQ thread did not stop within 5 second timeout.")
+            else:
+                logger.debug(f"[{self.storage_manager_id}]: Notify ZMQ thread shut down.")
 
         self.zmq_context.term()
-
-        logger.debug(f"[{self.storage_manager_id}]: Notify ZMQ thread shut down.")
 
     def __del__(self):
         """Destructor to ensure resources are cleaned up."""

--- a/transfer_queue/storage/managers/base.py
+++ b/transfer_queue/storage/managers/base.py
@@ -354,6 +354,7 @@ class StorageManager(ABC):
 
     def close(self) -> None:
         """Close all ZMQ sockets/contexts and stop the notify loop."""
+
         if self.controller_handshake_socket:
             try:
                 if not self.controller_handshake_socket.closed:
@@ -361,11 +362,9 @@ class StorageManager(ABC):
             except Exception as e:
                 logger.error(f"[{self.storage_manager_id}]: Error closing controller_handshake_socket: {str(e)}")
 
-        if not hasattr(self, "_notify_loop") or not self._notify_loop.is_running():
-            return
-
-        self._notify_loop.call_soon_threadsafe(self._notify_loop.stop)
-        self._notify_thread.join(timeout=5)
+        if hasattr(self, "_notify_loop") and self._notify_loop.is_running():
+            self._notify_loop.call_soon_threadsafe(self._notify_loop.stop)
+            self._notify_thread.join(timeout=5)
 
         self.zmq_context.term()
 


### PR DESCRIPTION
Root cause: `notify_data_update` ran on the caller's asyncio loop. Under heavy compute workloads (PyTorch, Ray), the loop would stall, causing `asyncio.wait_for` timers to fire before the controller ACK was ever read.

Changes:
- Spin up a dedicated daemon thread (`_notify_thread`) running an isolated `_notify_loop` per StorageManager instance, keeping notify I/O immune to caller-side event loop starvation
- Bridge calls via `run_coroutine_threadsafe` + `wrap_future` so the caller-side `await` remains non-blocking
- Add `_notify_lock` to serialize concurrent `notify_data_update` calls on the dynamic socket, preventing send/recv interleaving across coroutines
- Guard `close()` with `hasattr(_notify_loop)` to avoid `AttributeError` in `__del__` when `__init__` fails before the loop is created