### PR TITLE
[fix] shared production_status tensor across data partitions

### DIFF
--- a/tests/e2e/test_kv_interface_e2e.py
+++ b/tests/e2e/test_kv_interface_e2e.py
@@ -946,7 +946,31 @@ class TestKVClearE2E:
 
         tq_api.kv_clear(keys=keys[2:], partition_id=partition_id)
 
-    def test_kv_clear_idempotent(self, controller, tq_api):
+    def test_kv_clear_does_not_leak_reused_index_across_partitions(self, controller, tq_api):
+        """Clearing a key in one partition must not make reused indexes visible there again."""
+        field_name = "x"
+        p1 = "clear_reuse_partition_1"
+        p2 = "clear_reuse_partition_2"
+
+        tq_api.kv_put(key="a", partition_id=p1, fields={field_name: torch.tensor([1])})
+        tq_api.kv_clear(keys="a", partition_id=p1)
+
+        tq_api.kv_put(key="b", partition_id=p2, fields={field_name: torch.tensor([2])})
+
+        leaked_meta = tq.get_client().get_meta(
+            data_fields=[field_name],
+            batch_size=1,
+            partition_id=p1,
+            mode="fetch",
+            task_name="clear_reuse_after_other_partition_put",
+        )
+
+        assert leaked_meta.size == 0
+        assert leaked_meta.global_indexes == []
+        assert not leaked_meta.is_ready
+
+
+def test_kv_clear_idempotent(self, controller, tq_api):
         """Test kv_clear is idempotent for non-existent keys and partitions."""
         partition_id = "test_partition"
         keys = ["idempotent_0", "idempotent_1", "idempotent_2", "idempotent_3"]

--- a/tests/e2e/test_kv_interface_e2e.py
+++ b/tests/e2e/test_kv_interface_e2e.py
@@ -970,7 +970,7 @@ class TestKVClearE2E:
         assert not leaked_meta.is_ready
 
 
-def test_kv_clear_idempotent(self, controller, tq_api):
+    def test_kv_clear_idempotent(self, controller, tq_api):
         """Test kv_clear is idempotent for non-existent keys and partitions."""
         partition_id = "test_partition"
         keys = ["idempotent_0", "idempotent_1", "idempotent_2", "idempotent_3"]

--- a/tests/e2e/test_kv_interface_e2e.py
+++ b/tests/e2e/test_kv_interface_e2e.py
@@ -969,7 +969,6 @@ class TestKVClearE2E:
         assert leaked_meta.global_indexes == []
         assert not leaked_meta.is_ready
 
-
     def test_kv_clear_idempotent(self, controller, tq_api):
         """Test kv_clear is idempotent for non-existent keys and partitions."""
         partition_id = "test_partition"

--- a/tests/test_controller_data_partitions.py
+++ b/tests/test_controller_data_partitions.py
@@ -107,6 +107,41 @@ def test_data_partition_status():
     print("DataPartitionStatus tests passed!\n")
 
 
+def test_data_partition_status_production_status_is_partition_local():
+    """Regression test that partitions do not share production_status tensors."""
+    from transfer_queue.controller import DataPartitionStatus
+
+    partition = DataPartitionStatus(partition_id="partition_a")
+    other_partition = DataPartitionStatus(partition_id="partition_b")
+
+    assert partition.production_status.data_ptr() != other_partition.production_status.data_ptr()
+
+
+def test_cleared_partition_does_not_observe_reused_index_from_other_partition():
+    """A cleared partition must not become ready when another partition reuses its index."""
+    from transfer_queue.controller import DataPartitionStatus
+
+    field_schema = {
+        "x": {
+            "dtype": "torch.int64",
+            "shape": (1,),
+            "is_nested": False,
+            "is_non_tensor": False,
+        }
+    }
+
+    partition = DataPartitionStatus(partition_id="partition_a")
+    other_partition = DataPartitionStatus(partition_id="partition_b")
+
+    assert partition.update_production_status([0], ["x"], field_schema=field_schema)
+    partition.clear_data([0], clear_consumption=True)
+    assert partition.scan_data_status(["x"], task_name="consumer_before_reuse") == []
+
+    assert other_partition.update_production_status([0], ["x"], field_schema=field_schema)
+
+    assert partition.scan_data_status(["x"], task_name="consumer_after_reuse") == []
+
+
 def test_partition_interface():
     """Test the partition interface design."""
     print("Testing partition interface design...")

--- a/transfer_queue/controller.py
+++ b/transfer_queue/controller.py
@@ -332,7 +332,6 @@ class DataPartitionStatus:
     # Values: 0 = not produced, 1 = ready for consumption
     TQ_PRE_ALLOC_SAMPLE_NUM = int(os.environ.get("TQ_PRE_ALLOC_SAMPLE_NUM", 1))
 
-    #production_status: Tensor = torch.zeros(TQ_PRE_ALLOC_SAMPLE_NUM, 1, dtype=torch.int8)
     production_status: Tensor = field(
         default_factory=lambda: torch.zeros(DataPartitionStatus.TQ_PRE_ALLOC_SAMPLE_NUM, 1, dtype=torch.int8)
     )

--- a/transfer_queue/controller.py
+++ b/transfer_queue/controller.py
@@ -332,7 +332,10 @@ class DataPartitionStatus:
     # Values: 0 = not produced, 1 = ready for consumption
     TQ_PRE_ALLOC_SAMPLE_NUM = int(os.environ.get("TQ_PRE_ALLOC_SAMPLE_NUM", 1))
 
-    production_status: Tensor = torch.zeros(TQ_PRE_ALLOC_SAMPLE_NUM, 1, dtype=torch.int8)
+    #production_status: Tensor = torch.zeros(TQ_PRE_ALLOC_SAMPLE_NUM, 1, dtype=torch.int8)
+    production_status: Tensor = field(
+        default_factory=lambda: torch.zeros(DataPartitionStatus.TQ_PRE_ALLOC_SAMPLE_NUM, 1, dtype=torch.int8)
+    )
 
     # Consumption status per task - task_name -> consumption_tensor
     # Each tensor tracks which samples have been consumed by that task


### PR DESCRIPTION
Create a fresh production_status tensor for each DataPartitionStatus instance.

## Root Cause
`production_status` was initialized as a tensor dataclass default. That tensor was created at class definition time and could be shared by multiple `DataPartitionStatus` instances. When one partition reused a released global index and marked it ready, another cleared partition could observe the same ready bit.

## Impact
A cleared partition could incorrectly return stale ready metadata. In the KV path, because storage keys are generated as `global_index@field`, this could cause reads from one partition to include data written by another partition.

## PoC

```python
def client_api_poc():
    import torch
    import transfer_queue as tq
    from tensordict import TensorDict

    client = tq.get_client()
    field = "x"

    # p1 writes then clears one sample.
    # p1_meta.global_indexes == [0]
    p1_meta = client.put(
        data=TensorDict({field: torch.tensor([[1]])}, batch_size=[1]),
        partition_id="p1",
    )
    client.clear_samples(p1_meta)

    # p2 may reuse the released global_index 0.
    # Before the fix, this updates the shared production_status tensor
    # and makes the already-cleared p1 look ready again.
    client.put(
        data=TensorDict({field: torch.tensor([[2]])}, batch_size=[1]),
        partition_id="p2",
    )

    leaked = client.get_meta(
        data_fields=[field],
        batch_size=1,
        partition_id="p1",
        mode="fetch",
        task_name="repro",
    )

    # Before fix:
    #   leaked.size == 1
    #   leaked.global_indexes == [0]
    #   leaked.partition_ids == ["p1"]
    #   leaked.field_names == []
    #   leaked.is_ready == True
    #   leaked.production_status.tolist() == [1]
    #
    # After fix:
    #   leaked.size == 0
    #   leaked.global_indexes == []
    #   leaked.partition_ids == []
    #   leaked.field_names == []
    #   leaked.is_ready == False
    #   leaked.production_status.tolist() == []

    assert leaked.size == 0
```

## Tests
- `python -m pytest tests/test_controller_data_partitions.py -q`
- `python -m pytest tests/e2e/test_kv_interface_e2e.py::TestKVClearE2E::test_kv_clear_does_not_leak_reused_index_across_partitions -q`