### PR TITLE
[fix] Allow kv_clear to work on tag-only entries with no field data

### DIFF
--- a/transfer_queue/client.py
+++ b/transfer_queue/client.py
@@ -475,12 +475,24 @@ class AsyncTransferQueueClient:
             if not self._controller:
                 raise RuntimeError("No controller registered")
 
+            # If field_names is empty,
+            # query the controller for the partition's fields before clearing meta.
+            if not metadata.field_names:
+                merged_field_schema: dict = {}
+                for partition_id in dict.fromkeys(metadata.partition_ids):
+                    partition_meta = await self._get_partition_meta(partition_id)
+                    if partition_meta:
+                        merged_field_schema.update(partition_meta.field_schema)
+                if merged_field_schema:
+                    metadata = metadata.copy()
+                    metadata.field_schema = merged_field_schema
+                    metadata._field_names = sorted(merged_field_schema.keys())
+
             # Clear the controller metadata
             await self._clear_meta_in_controller(metadata)
 
-            # Clear storage unit data (skip if no fields, e.g. tag-only entries)
-            if metadata.field_names:
-                await self.storage_manager.clear_data(metadata)
+            # Clear storage unit data
+            await self.storage_manager.clear_data(metadata)
 
             logger.debug(f"[{self.client_id}]: Clear operation for batch {metadata} completed.")
         except Exception as e:

--- a/transfer_queue/client.py
+++ b/transfer_queue/client.py
@@ -478,8 +478,9 @@ class AsyncTransferQueueClient:
             # Clear the controller metadata
             await self._clear_meta_in_controller(metadata)
 
-            # Clear storage unit data
-            await self.storage_manager.clear_data(metadata)
+            # Clear storage unit data (skip if no fields, e.g. tag-only entries)
+            if metadata.field_names:
+                await self.storage_manager.clear_data(metadata)
 
             logger.debug(f"[{self.client_id}]: Clear operation for batch {metadata} completed.")
         except Exception as e:

--- a/transfer_queue/storage/managers/base.py
+++ b/transfer_queue/storage/managers/base.py
@@ -695,9 +695,8 @@ class KVStorageManager(StorageManager):
         """Remove stored data associated with the given metadata."""
 
         if not metadata.field_names:
-            raise RuntimeError(
-                "Fail to clear_data for key-value based backends due to lack of `field_names` in BatchMeta"
-            )
+            logger.debug("clear_data called with no field_names; nothing to clear for KV-based backend.")
+            return
 
         keys = self._generate_keys(metadata.field_names, metadata.global_indexes)
         _, _, custom_meta = self._get_shape_type_custom_backend_meta_list(metadata)


### PR DESCRIPTION
Previously, calling kv_clear on a key that was put via async_kv_put with only a tag (e.g. {"status": "finished"}) and no fields would raise:

RuntimeError: Fail to clear_data for key-value based backends due to lack of `field_names` in BatchMeta

This happened because async_clear_samples always called storage_manager.clear_data, which requires field_names to generate storage keys. For tag-only entries, nothing was ever written to the storage backend, so there is nothing to clear there.

Fix: skip storage_manager.clear_data when metadata.field_names is empty, and only clear the controller-side metadata.