### PR TITLE
[fix] Clear storage data before releasing controller indexes

### DIFF
--- a/transfer_queue/client.py
+++ b/transfer_queue/client.py
@@ -442,11 +442,11 @@ class AsyncTransferQueueClient:
                 )
                 return
 
-            # Clear the controller metadata
-            await self._clear_partition_in_controller(partition_id)
-
             # Clear storage unit data
             await self.storage_manager.clear_data(metadata)
+
+            # Clear the controller metadata
+            await self._clear_partition_in_controller(partition_id)
 
             logger.debug(f"[{self.client_id}]: Clear operation for partition_id {partition_id} completed.")
         except Exception as e:
@@ -475,11 +475,12 @@ class AsyncTransferQueueClient:
             if not self._controller:
                 raise RuntimeError("No controller registered")
 
-            # Clear the controller metadata
-            await self._clear_meta_in_controller(metadata)
-
-            # Clear storage unit data
+            # Clear storage unit data first, so released indexes are not reused
+            # before the underlying storage is actually freed.
             await self.storage_manager.clear_data(metadata)
+
+            # Clear the controller metadata (releases indexes to reusable pool)
+            await self._clear_meta_in_controller(metadata)
 
             logger.debug(f"[{self.client_id}]: Clear operation for batch {metadata} completed.")
         except Exception as e:

--- a/transfer_queue/client.py
+++ b/transfer_queue/client.py
@@ -475,11 +475,10 @@ class AsyncTransferQueueClient:
             if not self._controller:
                 raise RuntimeError("No controller registered")
 
-            # Clear storage unit data first, so released indexes are not reused
-            # before the underlying storage is actually freed.
+            # Clear storage unit data
             await self.storage_manager.clear_data(metadata)
 
-            # Clear the controller metadata (releases indexes to reusable pool)
+            # Clear the controller metadata
             await self._clear_meta_in_controller(metadata)
 
             logger.debug(f"[{self.client_id}]: Clear operation for batch {metadata} completed.")


### PR DESCRIPTION
Previously, the clear operation released the storage unit index in the controller before freeing the underlying storage memory. A concurrent actor could acquire the released index, write new data, and then have that data freed by the trailing storage clear — causing silent data loss and missing-field errors on the index during long training runs.

Fix by reversing the order: free storage memory first, then release the index back to the controller's reusable pool.