### PR TITLE
[fix] Guarantee even node distribution for simple storage units

### DIFF
--- a/scripts/performance_test/perftest_config.yaml
+++ b/scripts/performance_test/perftest_config.yaml
@@ -25,8 +25,9 @@ backend:
   SimpleStorage:
     # Maximum number of experience samples to hold across all storage units
     total_storage_size: 100000
-    # Number of distributed storage units.
-    # Recommended: >= 2 x number of nodes for load balancing.
+    # Number of distributed storage units. Units are round-robin scheduled across all
+    # alive Ray nodes, guaranteeing an even split of memory/bandwidth usage per node.
+    # Recommended: >= 2 x number of nodes so each node hosts multiple units.
     num_data_storage_units: 16
     # ZMQ Server IP & Ports (automatically generated during init)
     zmq_info: null

--- a/transfer_queue/config.yaml
+++ b/transfer_queue/config.yaml
@@ -26,8 +26,9 @@ backend:
     # Maximum number of experience samples to hold across all storage units.
     # Set to null for unlimited capacity (no capacity check).
     total_storage_size: null
-    # Number of distributed storage units.
-    # Recommended: >= 2 x number of nodes for load balancing.
+    # Number of distributed storage units. Units are round-robin scheduled across all
+    # alive Ray nodes, guaranteeing an even split of memory/bandwidth usage per node.
+    # Recommended: >= 2 x number of nodes so each node hosts multiple units.
     num_data_storage_units: 2
     # ZMQ Server IP & Ports (automatically generated during init)
     zmq_info: null

--- a/transfer_queue/storage/bootstrap/simple_storage_bootstrap.py
+++ b/transfer_queue/storage/bootstrap/simple_storage_bootstrap.py
@@ -20,7 +20,7 @@ from omegaconf import DictConfig
 
 from transfer_queue.storage.bootstrap.provider import StorageBootstrapProvider
 from transfer_queue.storage.simple_storage import SimpleStorageUnit
-from transfer_queue.utils.common import get_placement_group
+from transfer_queue.utils.common import get_node_round_robin_scheduling_strategies
 from transfer_queue.utils.logging_utils import get_logger
 from transfer_queue.utils.zmq_utils import process_zmq_server_info
 
@@ -34,7 +34,7 @@ def initialize_simple_storage(conf: DictConfig) -> dict[str, Any]:
     simple_storage_handles = {}
     num_data_storage_units = conf.backend.SimpleStorage.num_data_storage_units
     total_storage_size = conf.backend.SimpleStorage.get("total_storage_size", None)
-    storage_placement_group = get_placement_group(num_data_storage_units, num_cpus_per_actor=1)
+    scheduling_strategies = get_node_round_robin_scheduling_strategies(num_data_storage_units)
 
     # Compute per-unit capacity: None means unlimited
     storage_unit_size = (
@@ -43,14 +43,16 @@ def initialize_simple_storage(conf: DictConfig) -> dict[str, Any]:
 
     for storage_unit_rank in range(num_data_storage_units):
         storage_node = SimpleStorageUnit.options(  # type: ignore[attr-defined]
-            placement_group=storage_placement_group,
-            placement_group_bundle_index=storage_unit_rank,
+            scheduling_strategy=scheduling_strategies[storage_unit_rank],
             name=f"TransferQueueStorageUnit#{storage_unit_rank}",
         ).remote(
             storage_unit_size=storage_unit_size,
         )
         simple_storage_handles[f"TransferQueueStorageUnit#{storage_unit_rank}"] = storage_node
-        logger.info(f"TransferQueueStorageUnit#{storage_unit_rank} has been created.")
+        logger.info(
+            f"TransferQueueStorageUnit#{storage_unit_rank} has been created "
+            f"on node {scheduling_strategies[storage_unit_rank].node_id}."
+        )
 
     storage_zmq_info = process_zmq_server_info(simple_storage_handles)
     backend_name = conf.backend.storage_backend

--- a/transfer_queue/utils/common.py
+++ b/transfer_queue/utils/common.py
@@ -19,6 +19,7 @@ from contextlib import contextmanager
 import psutil
 import ray
 import torch
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 from transfer_queue.utils.logging_utils import get_logger
 
@@ -42,6 +43,33 @@ def get_placement_group(num_ray_actors: int, num_cpus_per_actor: int = 1):
     placement_group = ray.util.placement_group([bundle for _ in range(num_ray_actors)], strategy="SPREAD")
     ray.get(placement_group.ready())
     return placement_group
+
+
+def get_node_round_robin_scheduling_strategies(num_actors: int) -> list[NodeAffinitySchedulingStrategy]:
+    """
+    Compute one scheduling strategy per actor that round-robins actors across all
+    currently alive Ray nodes, in order.
+
+    Unlike a placement group with SPREAD (best-effort) or STRICT_SPREAD (fails when
+    num_actors > num_nodes), this guarantees each node is assigned floor(num_actors /
+    num_nodes) or ceil(num_actors / num_nodes) actors, regardless of how num_actors
+    compares to the number of nodes.
+
+    Args:
+        num_actors (int): Number of Ray actors to schedule.
+
+    Returns:
+        list[NodeAffinitySchedulingStrategy]: One scheduling strategy per actor.
+    """
+    nodes = ray.nodes()
+    alive_node_ids = sorted(node["NodeID"] for node in nodes if node.get("Alive", False))
+    if not alive_node_ids:
+        raise RuntimeError("No alive Ray nodes found. Is Ray initialized?")
+
+    return [
+        NodeAffinitySchedulingStrategy(node_id=alive_node_ids[i % len(alive_node_ids)], soft=False)
+        for i in range(num_actors)
+    ]
 
 
 @contextmanager


### PR DESCRIPTION
## Motivation

`SimpleStorage` fans experience data out across `num_data_storage_units` Ray actors. For memory and network bandwidth to be balanced across the cluster, those units must be spread evenly over the available Ray nodes — otherwise a subset of nodes absorbs a disproportionate share of the storage load and becomes a hotspot. The current placement relies on a placement group with the `SPREAD` strategy, which does not actually guarantee this.

## What was wrong

1. **`SPREAD` is best-effort, not a guarantee.** `initialize_simple_storage` created a placement group via `get_placement_group(num_data_storage_units)`, which builds one CPU bundle per unit with `ray.util.placement_group(..., strategy="SPREAD")`. Ray's `SPREAD` is explicitly documented as best-effort: when scheduling is constrained (resource pressure, timing, node availability) it silently falls back to packing multiple bundles — and therefore multiple storage units — onto the same node.
2. **No control over the units-vs-nodes ratio.** `SPREAD` gives no even-split guarantee regardless of how `num_data_storage_units` compares to the node count, and its strict sibling `STRICT_SPREAD` isn't a usable alternative here because it *fails outright* once `num_actors > num_nodes` (the common case, since the recommended setting is ≥ 2× nodes). The result: uneven memory/bandwidth distribution and node hotspots that the "spread" was supposed to prevent.

## What this changes

1. **Explicit round-robin placement via `NodeAffinitySchedulingStrategy`.** New helper `get_node_round_robin_scheduling_strategies(num_actors)` in `transfer_queue/utils/common.py` enumerates all currently alive Ray nodes (`ray.nodes()` filtered by `Alive`, sorted by `NodeID` for deterministic ordering) and returns one strategy per actor, assigning actor `i` to `alive_node_ids[i % len(alive_node_ids)]` with `soft=False` (hard affinity). This guarantees each node receives `floor(num_actors / num_nodes)` or `ceil(num_actors / num_nodes)` units — an even split by construction, for **any** ratio of units to nodes.
2. **`initialize_simple_storage` now schedules per-unit.** It calls `get_node_round_robin_scheduling_strategies(num_data_storage_units)` and passes `scheduling_strategy=strategies[rank]` to each `SimpleStorageUnit.options(...)`, replacing the previous `placement_group` + `placement_group_bundle_index` wiring. The creation log line now records the target `node_id` for each unit, making the distribution observable.
3. **Fail-fast on an empty cluster.** If no alive nodes are found, the helper raises `RuntimeError("No alive Ray nodes found. Is Ray initialized?")` instead of proceeding with an undefined placement.
4. **Config doc clarified.** `config.yaml` documents that units are round-robin scheduled across all alive nodes for an even per-node split, and keeps the "≥ 2× nodes" recommendation (now framed as "so each node hosts multiple units").

## Tests

Verified on a Ray cluster that `num_data_storage_units` units are distributed evenly across alive nodes for both `units ≤ nodes` and `units > nodes` cases, with each unit's target node confirmed via the new creation log line. Existing `SimpleStorage` unit and e2e lifecycle tests continue to pass.
