### PR TITLE
[fix] Do not log an expected concurrent-clear key miss as an error

### DIFF
--- a/tests/test_storage_key_race.py
+++ b/tests/test_storage_key_race.py
@@ -1,0 +1,84 @@
+# Copyright 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2025 The TransferQueue Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A key removed by a concurrent ``clear`` must stay distinguishable from a real storage fault."""
+
+import logging
+
+import pytest
+import torch
+
+from transfer_queue.storage.simple_storage import (
+    KEY_NOT_FOUND_MARKER,
+    SimpleStorageUnit,
+    StorageKeyNotFoundError,
+    StorageUnitData,
+)
+from transfer_queue.utils.zmq_utils import ZMQMessage, ZMQRequestType
+
+
+@pytest.fixture
+def storage_data():
+    data = StorageUnitData()
+    data.put_data({"log_probs": [torch.tensor([1.0]), torch.tensor([2.0])]}, [0, 1])
+    return data
+
+
+def test_cleared_key_raises_key_not_found(storage_data):
+    storage_data.clear([1])
+
+    with pytest.raises(StorageKeyNotFoundError, match="key 1 not found in field 'log_probs'"):
+        storage_data.get_data(["log_probs"], [0, 1])
+
+
+def test_key_not_found_is_a_key_error(storage_data):
+    # Subclassing KeyError keeps callers that already catch KeyError working.
+    storage_data.clear([0])
+
+    with pytest.raises(KeyError):
+        storage_data.get_data(["log_probs"], [0])
+
+
+def test_unknown_field_still_raises_value_error(storage_data):
+    # A field absent from the schema is a caller bug, not the clear race.
+    with pytest.raises(ValueError, match="field 'missing' not found"):
+        storage_data.get_data(["missing"], [0])
+
+
+def test_surviving_key_is_unaffected(storage_data):
+    storage_data.clear([1])
+
+    torch.testing.assert_close(storage_data.get_data(["log_probs"], [0])["log_probs"][0], torch.tensor([1.0]))
+
+
+def test_get_error_reply_is_marked_and_logged_at_debug(storage_data, caplog):
+    # The reply crosses ZMQ as text, so the marker is what lets the caller rebuild the type.
+    storage_data.clear([1])
+    unit_class = SimpleStorageUnit.__ray_metadata__.modified_class
+    unit = unit_class.__new__(unit_class)
+    unit.storage_unit_id = "storage_unit_0"
+    unit.storage_data = storage_data
+    request = ZMQMessage.create(
+        request_type=ZMQRequestType.GET_DATA,
+        sender_id="client_0",
+        body={"fields": ["log_probs"], "global_indexes": [1]},
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="transfer_queue.storage.simple_storage"):
+        reply = unit_class._handle_get(unit, request)
+
+    assert reply.request_type == ZMQRequestType.GET_ERROR
+    assert KEY_NOT_FOUND_MARKER in reply.body["message"]
+    assert [record for record in caplog.records if record.levelno >= logging.ERROR] == []

--- a/transfer_queue/__init__.py
+++ b/transfer_queue/__init__.py
@@ -43,6 +43,7 @@ from .sampler.grpo_group_n_sampler import GRPOGroupNSampler
 from .sampler.rank_aware_sampler import RankAwareSampler
 from .sampler.seqlen_balanced_sampler import SeqlenBalancedSampler
 from .sampler.sequential_sampler import SequentialSampler
+from .storage import StorageKeyNotFoundError
 
 __all__ = (
     [
@@ -79,6 +80,7 @@ __all__ = (
         "get_client",
         "BatchMeta",
         "TransferQueueClient",
+        "StorageKeyNotFoundError",
     ]
     + [
         # Sampler

--- a/transfer_queue/storage/__init__.py
+++ b/transfer_queue/storage/__init__.py
@@ -21,11 +21,12 @@ from .managers import (
     StorageManagerFactory,
     YuanrongStorageManager,
 )
-from .simple_storage import SimpleStorageUnit, StorageUnitData
+from .simple_storage import SimpleStorageUnit, StorageKeyNotFoundError, StorageUnitData
 
 __all__ = [
     "SimpleStorageUnit",
     "StorageUnitData",
+    "StorageKeyNotFoundError",
     "StorageManager",
     "StorageManagerFactory",
     "AsyncSimpleStorageManager",

--- a/transfer_queue/storage/managers/simple_storage_manager.py
+++ b/transfer_queue/storage/managers/simple_storage_manager.py
@@ -29,6 +29,7 @@ from tensordict import NonTensorStack, TensorDict
 
 from transfer_queue.metadata import BatchMeta, extract_field_schema
 from transfer_queue.storage.managers.base import StorageManager, StorageManagerFactory
+from transfer_queue.storage.simple_storage import KEY_NOT_FOUND_MARKER, StorageKeyNotFoundError
 from transfer_queue.utils.logging_utils import get_logger
 from transfer_queue.utils.zmq_utils import (
     ZMQMessage,
@@ -410,11 +411,14 @@ class AsyncSimpleStorageManager(StorageManager):
         try:
             results = await asyncio.gather(*tasks)
         except Exception as e:
-            logger.error(
+            # The offending unit is named in the error itself; the full routing list can run to
+            # hundreds of ids, which buries it.
+            log = logger.debug if isinstance(e, StorageKeyNotFoundError) else logger.error
+            log(
                 f"[{self.storage_manager_id}]: get_data failed. "
                 f"partition_id={metadata.partition_ids[0]}, "
                 f"num_samples={metadata.size}, "
-                f"storage_units={list(routing.keys())}, "
+                f"num_storage_units={len(routing)}, "
                 f"error={type(e).__name__}: {e}"
             )
             raise
@@ -456,10 +460,9 @@ class AsyncSimpleStorageManager(StorageManager):
                 storage_unit_data = response_msg.body["data"]
                 return fields, storage_unit_data
             else:
-                raise RuntimeError(
-                    f"Failed to get data from storage unit {target_storage_unit}: "
-                    f"{response_msg.body.get('message', 'Unknown error')}"
-                )
+                message = response_msg.body.get("message", "Unknown error")
+                error_type = StorageKeyNotFoundError if KEY_NOT_FOUND_MARKER in message else RuntimeError
+                raise error_type(f"Failed to get data from storage unit {target_storage_unit}: {message}")
         except zmq.error.Again as e:
             timeout_sec = TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT
             logger.error(
@@ -468,6 +471,9 @@ class AsyncSimpleStorageManager(StorageManager):
                 f"The storage unit may be overloaded or crashed."
             )
             raise RuntimeError(f"ZMQ recv timeout ({timeout_sec}s) from storage unit {target_storage_unit}") from e
+        except StorageKeyNotFoundError:
+            # Already logged at debug by the storage unit; propagate for the caller to classify.
+            raise
         except Exception as e:
             logger.error(
                 f"[{self.storage_manager_id}]: Unexpected error from storage unit "

--- a/transfer_queue/storage/simple_storage.py
+++ b/transfer_queue/storage/simple_storage.py
@@ -47,6 +47,18 @@ logger = get_logger(__name__)
 TQ_STORAGE_POLLER_TIMEOUT = int(os.environ.get("TQ_STORAGE_POLLER_TIMEOUT", 5))  # in seconds
 TQ_NUM_THREADS = int(os.environ.get("TQ_NUM_THREADS", 8))
 
+# Marks a GET_ERROR reply as "the key is gone" so the caller can tell it apart from a real fault.
+KEY_NOT_FOUND_MARKER = "TQKeyNotFound"
+
+
+class StorageKeyNotFoundError(KeyError):
+    """Raised when a requested global index is absent from a storage unit.
+
+    Reads and ``clear`` are concurrent by design, so a key returned by ``kv_retrieve_meta`` can be
+    cleared before ``get_data`` reaches the storage unit. Callers that tolerate that race catch this
+    instead of matching on message text.
+    """
+
 
 class StorageUnitData:
     """Storage unit for managing 2D data structure (samples × fields).
@@ -93,7 +105,7 @@ class StorageUnitData:
             try:
                 result[field] = [self.field_data[field][k] for k in global_indexes]
             except KeyError as e:
-                raise KeyError(f"StorageUnitData get_data: key {e} not found in field '{field}'") from e
+                raise StorageKeyNotFoundError(f"StorageUnitData get_data: key {e} not found in field '{field}'") from e
         return result
 
     def put_data(self, field_data: dict[str, Any], global_indexes: list) -> None:
@@ -452,15 +464,18 @@ class SimpleStorageUnit:
                 },
             )
         except Exception as e:
-            logger.error(
+            key_not_found = isinstance(e, StorageKeyNotFoundError)
+            log = logger.debug if key_not_found else logger.error
+            log(
                 f"[{self.storage_unit_id}]: _handle_get error, "
                 f"fields={fields}, global_indexes={global_indexes}: {type(e).__name__}: {e}"
             )
+            marker = f"[{KEY_NOT_FOUND_MARKER}] " if key_not_found else ""
             response_msg = ZMQMessage.create(
                 request_type=ZMQRequestType.GET_ERROR,  # type: ignore[arg-type]
                 sender_id=self.storage_unit_id,
                 body={
-                    "message": f"Failed to get data from storage unit id #{self.storage_unit_id}, "
+                    "message": f"{marker}Failed to get data from storage unit id #{self.storage_unit_id}, "
                     f"detail error message: {str(e)}"
                 },
             )


### PR DESCRIPTION
## Motivation

  `kv_batch_get` resolves metadata and then fetches data, holding no lease across
  the two steps:

```python
  batch_meta = tq_client.kv_retrieve_meta(keys=keys, partition_id=partition_id, create=False)
  ...
  data = tq_client.get_data(batch_meta)
```

  A `kv_clear` from another client can land in between, so `get_data` reaches a
  storage unit whose key is gone. Both are public APIs and TransferQueue is built
  for "fine-grained, concurrent data read/write operations", so concurrent readers
  and cleaners are the advertised use case.

  Reproducing this on current `main` — one process clears the keys another already
  resolved metadata for:

```python
  meta = client.kv_retrieve_meta(keys=keys, partition_id=p, create=False)  # 8 keys, ready
  ray.get(clear_from_another_process.remote(p, keys))
  client.get_data(meta)
```

```
  ERROR ... _handle_get error, fields=['data'], global_indexes=[0, 2, 4, 6]:
        KeyError: "StorageUnitData get_data: key 0 not found in field 'data'"
  ERROR ... Unexpected error from storage unit TQ_STORAGE_UNIT_8156e4cb: RuntimeError: ...
  ERROR ... get_data failed. ... storage_units=['TQ_STORAGE_UNIT_8156e4cb', ...], ...
```

Three ERROR lines across two processes for one expected event. Two problems:

  - **Severity.** The condition is expected under concurrency and retryable, but at
    ERROR it is indistinguishable from a real storage fault and trips log-based
    alerting. The controller already treats the analogous case as a warning:
    `logger.warning(f"Partition {partition_id} were not found in controller!")`.
  - **Callers cannot classify it.** It surfaces as a generic `RuntimeError` whose
    message is assembled across a ZMQ hop, so the only way to tolerate the race is
    substring matching on the message, which breaks when the wording changes.

  The third line also logs the whole routing table. With many storage units that is
  hundreds of ids on one line, burying the unit, key and field the error already
  names.

## Modification

  - Add `StorageKeyNotFoundError(KeyError)`, raised by `StorageUnitData.get_data`
    when a global index is absent.
  - Tag the `GET_ERROR` reply so the manager can rebuild the type after the ZMQ hop
    rather than flattening it into `RuntimeError`.
  - Log this condition at DEBUG in all three places. Every other failure keeps its
    ERROR level and message; an unknown *field* still raises `ValueError` at ERROR,
    since that is a caller bug rather than the race.
  - Replace `storage_units={list(routing.keys())}` with `num_storage_units={len(routing)}`.
  - Export `StorageKeyNotFoundError` from `transfer_queue`.

## Test

  `tests/test_storage_key_race.py`: a cleared key raises `StorageKeyNotFoundError`;
  it is still a `KeyError`; an unknown field still raises `ValueError`; a surviving
  key is unaffected; and `_handle_get` marks the `GET_ERROR` reply while emitting no
  ERROR record.