### PR TITLE
[fix] Reject foreign ZMQ peers at the storage proxy

### DIFF
--- a/tests/test_simple_storage_unit.py
+++ b/tests/test_simple_storage_unit.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import time
+from uuid import uuid4
 
 import pytest
 import ray
@@ -22,15 +23,24 @@ import torch
 import zmq
 
 from transfer_queue.storage.simple_storage import SimpleStorageUnit
-from transfer_queue.utils.zmq_utils import ZMQMessage, ZMQRequestType, create_zmq_socket
+from transfer_queue.utils.zmq_utils import (
+    STORAGE_MANAGER_IDENTITY_PREFIX,
+    ZMQMessage,
+    ZMQRequestType,
+    create_zmq_socket,
+)
 
 
 class MockStorageClient:
     """Mock client for testing storage unit operations."""
 
-    def __init__(self, storage_put_get_address, storage_ip):
+    def __init__(self, storage_put_get_address, storage_ip, identity=None):
         self.context = zmq.Context()
-        self.socket = create_zmq_socket(self.context, zmq.DEALER, storage_ip)
+        # The storage proxy drops identities outside STORAGE_CLIENT_IDENTITY_PREFIXES, so mirror
+        # the prefix a real storage manager uses instead of letting ZMQ auto-assign one.
+        if identity is None:
+            identity = f"{STORAGE_MANAGER_IDENTITY_PREFIX}{uuid4().hex[:8]}".encode()
+        self.socket = create_zmq_socket(self.context, zmq.DEALER, storage_ip, identity=identity)
         self.socket.setsockopt(zmq.RCVTIMEO, 5000)  # 5 second timeout
         self.socket.connect(storage_put_get_address)
 
@@ -730,4 +740,37 @@ def test_storage_unit_checkpoint_load_missing_file(storage_setup, tmp_path):
     assert response.body["success"] is False
     assert "message" in response.body
 
+    client.close()
+
+
+def test_foreign_payload_dropped_and_unit_stays_usable(storage_setup):
+    """A non-TransferQueue peer (e.g. a TLS probe) must not stop the proxy."""
+    _, put_get_address, storage_ip = storage_setup
+
+    foreign = MockStorageClient(put_get_address, storage_ip, identity=b"foreign_probe")
+    foreign.socket.setsockopt(zmq.RCVTIMEO, 1000)
+    # A TLS ClientHello record header: what a port scanner sends to an unknown TCP port.
+    foreign.socket.send(b"\x16\x03\x01\x02\x00")
+    # Dropped before the worker, so unlike a decode failure it draws no reply at all.
+    with pytest.raises(zmq.Again):
+        foreign.socket.recv_multipart()
+    foreign.close()
+
+    client = MockStorageClient(put_get_address, storage_ip)
+    response = client.send_put(0, [0], {"val": [torch.tensor([1.0])]})
+    assert response.request_type == ZMQRequestType.PUT_DATA_RESPONSE
+    client.close()
+
+
+def test_undecodable_request_answered_and_worker_survives(storage_setup):
+    """An allowed identity passes the proxy, so the worker itself must survive bad frames."""
+    _, put_get_address, storage_ip = storage_setup
+
+    client = MockStorageClient(put_get_address, storage_ip)
+    client.socket.send_multipart([b"\x16\x03\x01\x02\x00"])
+    response = ZMQMessage.deserialize(client.socket.recv_multipart(copy=False))
+    assert response.request_type == ZMQRequestType.PUT_GET_ERROR
+
+    response = client.send_put(0, [0], {"val": [torch.tensor([1.0])]})
+    assert response.request_type == ZMQRequestType.PUT_DATA_RESPONSE
     client.close()

--- a/transfer_queue/metrics.py
+++ b/transfer_queue/metrics.py
@@ -26,6 +26,7 @@ from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
 
 from transfer_queue.utils.logging_utils import get_logger
 from transfer_queue.utils.zmq_utils import (
+    METRICS_COLLECTOR_IDENTITY_PREFIX,
     ZMQMessage,
     ZMQRequestType,
     ZMQServerInfo,
@@ -380,7 +381,7 @@ class TQMetricsExporter:
         if sock is not None and not sock.closed:
             return sock
 
-        identity = f"metrics_collector_{uuid4().hex[:8]}".encode()
+        identity = f"{METRICS_COLLECTOR_IDENTITY_PREFIX}{uuid4().hex[:8]}".encode()
         sock = create_zmq_socket(self._zmq_ctx, zmq.DEALER, su_info.ip, identity)
         timeout_ms = TQ_METRICS_STORAGE_TIMEOUT * 1000
         address = format_zmq_address(su_info.ip, su_info.ports["put_get_socket"])

--- a/transfer_queue/storage/managers/base.py
+++ b/transfer_queue/storage/managers/base.py
@@ -36,7 +36,13 @@ from torch import Tensor
 from transfer_queue.metadata import BatchMeta, extract_field_schema
 from transfer_queue.storage.clients.base import StorageClientFactory
 from transfer_queue.utils.logging_utils import get_logger
-from transfer_queue.utils.zmq_utils import ZMQMessage, ZMQRequestType, ZMQServerInfo, create_zmq_socket
+from transfer_queue.utils.zmq_utils import (
+    STORAGE_MANAGER_IDENTITY_PREFIX,
+    ZMQMessage,
+    ZMQRequestType,
+    ZMQServerInfo,
+    create_zmq_socket,
+)
 
 logger = get_logger(__name__)
 
@@ -70,7 +76,7 @@ class StorageManager(ABC):
         config: DictConfig,
         zmq_context: zmq.asyncio.Context | None = None,
     ):
-        self.storage_manager_id = f"TQ_STORAGE_{uuid4().hex[:8]}"
+        self.storage_manager_id = f"{STORAGE_MANAGER_IDENTITY_PREFIX}{uuid4().hex[:8]}"
         self.config = config
         self.controller_info = controller_info
 

--- a/transfer_queue/storage/simple_storage.py
+++ b/transfer_queue/storage/simple_storage.py
@@ -30,6 +30,7 @@ from transfer_queue.utils.enum_utils import Role
 from transfer_queue.utils.logging_utils import get_logger
 from transfer_queue.utils.perf_utils import IntervalPerfMonitor
 from transfer_queue.utils.zmq_utils import (
+    STORAGE_CLIENT_IDENTITY_PREFIXES,
     ZMQMessage,
     ZMQRequestType,
     ZMQServerInfo,
@@ -262,8 +263,29 @@ class SimpleStorageUnit:
     def _proxy_routine(self) -> None:
         """ZMQ proxy for message forwarding between frontend ROUTER and backend DEALER."""
         logger.info(f"[{self.storage_unit_id}]: start ZMQ proxy...")
+        assert self.put_get_socket is not None, "put_get_socket is not properly initialized"
+        front, back = self.put_get_socket, self.worker_socket
+        poller = zmq.Poller()
+        poller.register(front, zmq.POLLIN)
+        poller.register(back, zmq.POLLIN)
         try:
-            zmq.proxy(self.put_get_socket, self.worker_socket)
+            # Forwarding by hand rather than via zmq.proxy() so a non-TransferQueue peer on
+            # this exposed TCP port cannot reach the worker and terminate its request loop.
+            while not self._shutdown_event.is_set():
+                events = dict(poller.poll(1000))
+                if front in events:
+                    messages = front.recv_multipart(copy=False)
+                    identity = bytes(messages[0]) if messages else b""
+                    if not identity.startswith(STORAGE_CLIENT_IDENTITY_PREFIXES):
+                        logger.warning(
+                            "[%s]: dropping request with unrecognized ZMQ identity",
+                            self.storage_unit_id,
+                        )
+                        continue
+                    back.send_multipart(messages, copy=False)
+
+                if back in events:
+                    front.send_multipart(back.recv_multipart(copy=False), copy=False)
         except zmq.ContextTerminated:
             logger.info(f"[{self.storage_unit_id}]: ZMQ Proxy stopped gracefully (Context Terminated)")
         except Exception as e:
@@ -305,7 +327,22 @@ class SimpleStorageUnit:
                 identity = messages[0]
                 serialized_msg = messages[1:]
 
-                request_msg = ZMQMessage.deserialize(serialized_msg)
+                try:
+                    request_msg = ZMQMessage.deserialize(serialized_msg)
+                except Exception as e:
+                    # The identity filter cannot cover this: an allowed peer can still send
+                    # frames that fail to decode, and decoding here used to kill the thread.
+                    logger.error(
+                        f"[{self.storage_unit_id}]: undecodable request from "
+                        f"identity={bytes(identity)!r}: {type(e).__name__}: {e}"
+                    )
+                    error_msg = ZMQMessage.create(
+                        request_type=ZMQRequestType.PUT_GET_ERROR,  # type: ignore[arg-type]
+                        sender_id=self.storage_unit_id,
+                        body={"message": f"undecodable request: {type(e).__name__}: {e}"},
+                    )
+                    worker_socket.send_multipart([identity] + error_msg.serialize(), copy=False)
+                    continue
                 operation = request_msg.request_type
 
                 try:

--- a/transfer_queue/utils/zmq_utils.py
+++ b/transfer_queue/utils/zmq_utils.py
@@ -32,6 +32,15 @@ from transfer_queue.utils.serial_utils import decode, encode
 
 logger = get_logger(__name__)
 
+# Identity prefixes of the peers allowed to reach a storage unit. The storage proxy drops
+# anything else, so an identity built without these prefixes is silently unreachable.
+STORAGE_MANAGER_IDENTITY_PREFIX = "TQ_STORAGE_"
+METRICS_COLLECTOR_IDENTITY_PREFIX = "metrics_collector_"
+STORAGE_CLIENT_IDENTITY_PREFIXES = (
+    STORAGE_MANAGER_IDENTITY_PREFIX.encode(),
+    METRICS_COLLECTOR_IDENTITY_PREFIX.encode(),
+)
+
 
 bytestr: TypeAlias = bytes | bytearray | memoryview
 


### PR DESCRIPTION
## Problem

A storage unit binds its put/get ROUTER to a TCP port. Anything that dials that
port is forwarded straight to the worker, and the worker then dies decoding it:
`ZMQMessage.deserialize` sat outside the worker's `try`, so one stray payload
terminated the request loop. The actor process, its bound socket and the proxy
thread all stayed up, so requests kept being accepted with nobody left to answer
them and every client blocked until its own timeout.

## Fix

1. **Filter at the proxy.** `zmq.proxy()` offers no interception point, so the
     proxy now forwards by hand and keeps only the two identity prefixes real peers
     use (storage managers and the metrics collector).
2. **Survive bad frames anyway.** The filter cannot cover everything: an allowed
peer can still send frames that fail to decode. Decoding moves inside the
     `try`, mirroring the controller's request loop, and the peer gets an error
     reply instead of hanging on `recv`.
3. **One source for the prefixes.** They now live in `zmq_utils` and the
     identities are built from them, so a rename cannot silently make every request
     unroutable.

The controller already tolerates undecodable messages, so it needs no change.

## Tests

`tests/test_simple_storage_unit.py`: 17 passed.

- `test_foreign_payload_dropped_and_unit_stays_usable` — feeds a real TLS
    ClientHello and asserts it draws *no reply at all* (dropped before the worker,
    unlike a decode failure), then that the unit still serves.
- `test_undecodable_request_answered_and_worker_survives` — an allowed identity
    sending undecodable frames gets `PUT_GET_ERROR` and the worker keeps serving.

Each was confirmed to fail when its corresponding fix is reverted.