### PR TITLE
[fix] Retry a lost storage-unit request instead of failing the job

### DIFF
--- a/tests/test_storage_request_retry.py
+++ b/tests/test_storage_request_retry.py
@@ -1,0 +1,215 @@
+# Copyright 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2025 The TransferQueue Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for storage-unit request retry and the timeout diagnosis that classifies a failure."""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+import torch
+import zmq
+
+from transfer_queue.storage.managers import simple_storage_manager as ssm
+from transfer_queue.storage.managers.simple_storage_manager import (
+    AsyncSimpleStorageManager,
+    StorageUnitTimeout,
+)
+from transfer_queue.utils.common import estimate_payload_bytes
+from transfer_queue.utils.enum_utils import Role
+from transfer_queue.utils.zmq_utils import ZMQServerInfo
+
+
+def _manager(**units: ZMQServerInfo) -> AsyncSimpleStorageManager:
+    """Build a manager carrying only the state the retry and diagnosis helpers read."""
+    manager = AsyncSimpleStorageManager.__new__(AsyncSimpleStorageManager)
+    manager.storage_manager_id = "TQ_STORAGE_test"
+    manager.storage_unit_infos = dict(units)
+    return manager
+
+
+def _server_info(unit_id: str, ip: str, port: int) -> ZMQServerInfo:
+    return ZMQServerInfo(role=Role.STORAGE, id=unit_id, ip=ip, ports={"put_get_socket": port})
+
+
+@pytest.mark.asyncio
+async def test_lost_request_recovers_on_retry():
+    """A request lost in flight must be recovered by a second attempt, not kill the job."""
+    manager = _manager(unit_a=_server_info("unit_a", "10.0.0.7", 5555))
+    attempts = []
+
+    async def flaky():
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise StorageUnitTimeout("no answer")
+        return "payload"
+
+    with patch.object(manager, "_diagnose_storage_unit") as diagnose:
+        result = await manager._request_with_retry("get", "unit_a", "samples=4", flaky)
+
+    assert result == "payload"
+    assert len(attempts) == 2, "the retry must issue a second attempt on a new connection"
+    assert diagnose.call_count == 0, "a recovered request must not pay for a diagnosis"
+
+
+@pytest.mark.asyncio
+async def test_retry_gives_up_after_configured_attempts():
+    """Attempts are bounded, and the final failure still raises for the caller to handle."""
+    manager = _manager(unit_a=_server_info("unit_a", "10.0.0.7", 5555))
+    attempts = []
+
+    async def always_timeout():
+        attempts.append(1)
+        raise StorageUnitTimeout("no answer")
+
+    with (
+        patch.object(ssm, "TQ_SIMPLE_STORAGE_MAX_ATTEMPTS", 3),
+        patch.object(manager, "_diagnose_storage_unit", return_value="diagnosis") as diagnose,
+        pytest.raises(StorageUnitTimeout),
+    ):
+        await manager._request_with_retry("get", "unit_a", "samples=4", always_timeout)
+
+    assert len(attempts) == 3
+    diagnose.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_errors_reported_by_the_unit_are_not_retried():
+    """Only a missing answer is worth another connection; a real error must surface at once."""
+    manager = _manager(unit_a=_server_info("unit_a", "10.0.0.7", 5555))
+    attempts = []
+
+    async def hard_failure():
+        attempts.append(1)
+        raise RuntimeError("storage unit rejected the request")
+
+    with pytest.raises(RuntimeError, match="rejected"):
+        await manager._request_with_retry("get", "unit_a", "samples=4", hard_failure)
+
+    assert len(attempts) == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_logs_endpoint_and_request_shape(caplog):
+    """The retry warning must name the endpoint and the request, to correlate both ends."""
+    manager = _manager(unit_a=_server_info("unit_a", "10.0.0.7", 5555))
+    attempts = []
+
+    async def flaky():
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise StorageUnitTimeout("no answer")
+        return "payload"
+
+    with caplog.at_level(logging.WARNING):
+        await manager._request_with_retry("get", "unit_a", "samples=4 fields=['input_ids']", flaky)
+
+    warning = next(r for r in caplog.records if "retry" in r.message)
+    assert "10.0.0.7:5555" in warning.message
+    assert "samples=4" in warning.message
+
+
+@pytest.mark.asyncio
+async def test_diagnosis_blames_the_link_when_the_unit_still_answers():
+    """A unit that answers a fresh probe was not the one that stalled."""
+    manager = _manager(unit_a=_server_info("unit_a", "10.0.0.7", 5555))
+    probe_body = {
+        "active_keys": 4,
+        "process_rss_bytes": 1_330_159_616,
+        "op_stats": {"GET_DATA": {"request_count": 1025}},
+    }
+
+    async def reachable(*args, **kwargs):
+        return None, _Writer()
+
+    with (
+        patch.object(ssm.asyncio, "open_connection", reachable),
+        patch.object(manager, "_probe_storage_unit", return_value=probe_body),
+    ):
+        diagnosis = await manager._diagnose_storage_unit("unit_a")
+
+    assert "tcp=up" in diagnosis
+    assert "verdict=request_lost_in_flight" in diagnosis
+    assert "1025" in diagnosis
+
+
+@pytest.mark.asyncio
+async def test_diagnosis_blames_the_unit_when_the_probe_times_out():
+    """A probe timeout means the worker thread itself stopped serving."""
+    manager = _manager(unit_a=_server_info("unit_a", "10.0.0.7", 5555))
+
+    async def reachable(*args, **kwargs):
+        return None, _Writer()
+
+    async def probe_timeout(**kwargs):
+        raise zmq.error.Again()
+
+    with (
+        patch.object(ssm.asyncio, "open_connection", reachable),
+        patch.object(manager, "_probe_storage_unit", probe_timeout),
+    ):
+        diagnosis = await manager._diagnose_storage_unit("unit_a")
+
+    assert "verdict=unit_not_serving" in diagnosis
+
+
+@pytest.mark.asyncio
+async def test_diagnosis_reports_an_unreachable_endpoint():
+    """When the port itself is gone the diagnosis must say so rather than blame the unit."""
+    manager = _manager(unit_a=_server_info("unit_a", "10.0.0.7", 5555))
+
+    async def refused(*args, **kwargs):
+        raise ConnectionRefusedError()
+
+    async def probe_timeout(**kwargs):
+        raise zmq.error.Again()
+
+    with (
+        patch.object(ssm.asyncio, "open_connection", refused),
+        patch.object(manager, "_probe_storage_unit", probe_timeout),
+    ):
+        diagnosis = await manager._diagnose_storage_unit("unit_a")
+
+    assert "tcp=down(ConnectionRefusedError)" in diagnosis
+
+
+@pytest.mark.asyncio
+async def test_diagnosis_never_raises_on_an_unknown_unit():
+    """Diagnosis runs while another failure is being reported and must not mask it."""
+    manager = _manager()
+
+    assert "unit_not_registered" in await manager._diagnose_storage_unit("missing_unit")
+
+
+class _Writer:
+    """Minimal stand-in for the writer half returned by ``asyncio.open_connection``."""
+
+    def close(self):
+        pass
+
+
+def test_estimate_payload_bytes_handles_put_and_get_shapes():
+    """Both the batched put shape and the per-sample get shape must be measurable."""
+    batched = {"input_ids": torch.zeros(4, 8, dtype=torch.int64)}
+    per_sample = {"input_ids": [torch.zeros(8, dtype=torch.int64) for _ in range(4)]}
+
+    assert estimate_payload_bytes(batched) == 4 * 8 * 8
+    assert estimate_payload_bytes(per_sample) == 4 * 8 * 8
+
+
+def test_estimate_payload_bytes_degrades_to_zero_on_unmeasurable_input():
+    """Size estimation is diagnostic only and must never break the path it reports on."""
+    assert estimate_payload_bytes(object()) == 0
+    assert estimate_payload_bytes({"meta": "not a tensor"}) == 0

--- a/tests/test_storage_request_retry.py
+++ b/tests/test_storage_request_retry.py
@@ -16,12 +16,15 @@
 """Tests for storage-unit request retry and the timeout diagnosis that classifies a failure."""
 
 import logging
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
+import numpy as np
 import pytest
 import torch
 import zmq
+from tensordict import TensorDict
 
+from transfer_queue.metadata import BatchMeta
 from transfer_queue.storage.managers import simple_storage_manager as ssm
 from transfer_queue.storage.managers.simple_storage_manager import (
     AsyncSimpleStorageManager,
@@ -37,11 +40,52 @@ def _manager(**units: ZMQServerInfo) -> AsyncSimpleStorageManager:
     manager = AsyncSimpleStorageManager.__new__(AsyncSimpleStorageManager)
     manager.storage_manager_id = "TQ_STORAGE_test"
     manager.storage_unit_infos = dict(units)
+    manager.close = lambda: None  # __init__ is skipped, so there is no socket or thread to close
     return manager
 
 
 def _server_info(unit_id: str, ip: str, port: int) -> ZMQServerInfo:
     return ZMQServerInfo(role=Role.STORAGE, id=unit_id, ip=ip, ports={"put_get_socket": port})
+
+
+def _single_sample_batch() -> tuple[TensorDict, BatchMeta]:
+    """One sample routed to one unit, the smallest input put_data accepts."""
+    metadata = BatchMeta(
+        global_indexes=[0],
+        partition_ids=["0"],
+        field_schema={"input_ids": {"dtype": torch.int64, "shape": (2,), "is_nested": False, "is_non_tensor": False}},
+        production_status=np.ones(1, dtype=np.int8),
+    )
+    return TensorDict({"input_ids": torch.zeros(1, 2, dtype=torch.int64)}, batch_size=1), metadata
+
+
+async def _failing_put_attempts(data_parser) -> int:
+    """Count the attempts put_data makes when the unit never answers."""
+    manager = _manager(unit_a=_server_info("unit_a", "10.0.0.7", 5555))
+    manager.notify_data_update = AsyncMock()
+    manager._put_to_single_storage_unit = AsyncMock(side_effect=StorageUnitTimeout("no answer"))
+    data, metadata = _single_sample_batch()
+
+    with (
+        patch.object(manager, "_diagnose_storage_unit", return_value="diagnosis"),
+        pytest.raises(StorageUnitTimeout),
+    ):
+        await manager.put_data(data, metadata, data_parser=data_parser)
+
+    manager.notify_data_update.assert_not_awaited()
+    return manager._put_to_single_storage_unit.await_count
+
+
+@pytest.mark.asyncio
+async def test_parser_backed_put_is_not_replayed():
+    """A parser re-runs on the unit, and the public API does not constrain its side effects."""
+    assert await _failing_put_attempts(data_parser=lambda field_data: field_data) == 1
+
+
+@pytest.mark.asyncio
+async def test_put_without_a_parser_is_still_retried():
+    """The retry must stay in force for the ordinary put, which is a plain overwrite."""
+    assert await _failing_put_attempts(data_parser=None) == ssm.TQ_SIMPLE_STORAGE_MAX_ATTEMPTS
 
 
 @pytest.mark.asyncio

--- a/tests/test_storage_request_retry.py
+++ b/tests/test_storage_request_retry.py
@@ -16,6 +16,7 @@
 """Tests for storage-unit request retry and the timeout diagnosis that classifies a failure."""
 
 import logging
+import time
 from unittest.mock import AsyncMock, patch
 
 import numpy as np
@@ -199,6 +200,22 @@ async def test_retry_logs_timeout_detail(caplog):
 
     warning = next(r for r in caplog.records if "retry" in r.message)
     assert "serialized_mb=12.5" in warning.message
+
+
+def test_manager_logs_heavy_put(caplog):
+    """A put that is large on the wire is logged on the manager, not the unit."""
+    manager = _manager(unit_a=_server_info("unit_a", "10.0.0.7", 5555))
+
+    with (
+        patch.object(ssm, "TQ_STORAGE_LARGE_PAYLOAD_MB", 0.0),
+        patch.object(ssm, "TQ_STORAGE_SLOW_REQUEST_SECONDS", 1e9),
+        caplog.at_level(logging.WARNING),
+    ):
+        manager._log_if_heavy_put(time.perf_counter(), 512 * 2**20, 4, ["input_ids"], "unit_a")
+
+    warning = next(r for r in caplog.records if "heavy put" in r.message)
+    assert "serialized_mb=512.0" in warning.message
+    assert "10.0.0.7:5555" in warning.message
 
 
 @pytest.mark.asyncio

--- a/tests/test_storage_request_retry.py
+++ b/tests/test_storage_request_retry.py
@@ -183,6 +183,25 @@ async def test_retry_logs_endpoint_and_request_shape(caplog):
 
 
 @pytest.mark.asyncio
+async def test_retry_logs_timeout_detail(caplog):
+    """The retry warning must carry the size reported by the failed attempt."""
+    manager = _manager(unit_a=_server_info("unit_a", "10.0.0.7", 5555))
+    attempts = []
+
+    async def flaky():
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise StorageUnitTimeout("serialized_mb=12.5")
+        return "payload"
+
+    with caplog.at_level(logging.WARNING):
+        await manager._request_with_retry("put", "unit_a", "samples=4", flaky)
+
+    warning = next(r for r in caplog.records if "retry" in r.message)
+    assert "serialized_mb=12.5" in warning.message
+
+
+@pytest.mark.asyncio
 async def test_diagnosis_blames_the_link_when_the_unit_still_answers():
     """A unit that answers a fresh probe was not the one that stalled."""
     manager = _manager(unit_a=_server_info("unit_a", "10.0.0.7", 5555))

--- a/tests/test_storage_request_retry.py
+++ b/tests/test_storage_request_retry.py
@@ -163,23 +163,24 @@ async def test_errors_reported_by_the_unit_are_not_retried():
 
 
 @pytest.mark.asyncio
-async def test_retry_logs_endpoint_and_request_shape(caplog):
-    """The retry warning must name the endpoint and the request, to correlate both ends."""
+async def test_retry_log_adds_request_shape_without_echoing_the_failure(caplog):
+    """The failure already names the unit and endpoint; the retry line adds shape, not an echo."""
     manager = _manager(unit_a=_server_info("unit_a", "10.0.0.7", 5555))
     attempts = []
 
     async def flaky():
         attempts.append(1)
         if len(attempts) == 1:
-            raise StorageUnitTimeout("no answer")
+            raise StorageUnitTimeout("no answer in 200s during get from storage unit unit_a at 10.0.0.7:5555")
         return "payload"
 
     with caplog.at_level(logging.WARNING):
         await manager._request_with_retry("get", "unit_a", "samples=4 fields=['input_ids']", flaky)
 
     warning = next(r for r in caplog.records if "retry" in r.message)
-    assert "10.0.0.7:5555" in warning.message
-    assert "samples=4" in warning.message
+    assert "samples=4 fields=['input_ids']" in warning.message
+    assert warning.message.count("10.0.0.7:5555") == 1
+    assert warning.message.count("unit_a") == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_storage_request_retry.py
+++ b/tests/test_storage_request_retry.py
@@ -16,7 +16,6 @@
 """Tests for storage-unit request retry and the timeout diagnosis that classifies a failure."""
 
 import logging
-import time
 from unittest.mock import AsyncMock, patch
 
 import numpy as np
@@ -31,7 +30,7 @@ from transfer_queue.storage.managers.simple_storage_manager import (
     AsyncSimpleStorageManager,
     StorageUnitTimeout,
 )
-from transfer_queue.utils.common import estimate_payload_bytes
+from transfer_queue.utils import common
 from transfer_queue.utils.enum_utils import Role
 from transfer_queue.utils.zmq_utils import ZMQServerInfo
 
@@ -202,20 +201,30 @@ async def test_retry_logs_timeout_detail(caplog):
     assert "serialized_mb=12.5" in warning.message
 
 
-def test_manager_logs_heavy_put(caplog):
-    """A put that is large on the wire is logged on the manager, not the unit."""
-    manager = _manager(unit_a=_server_info("unit_a", "10.0.0.7", 5555))
-
+def test_log_heavy_operation_reports_the_measured_wire_size(caplog):
+    """Both call sites hand over serialized bytes, so the message reports them as measured."""
     with (
-        patch.object(ssm, "TQ_STORAGE_LARGE_PAYLOAD_MB", 0.0),
-        patch.object(ssm, "TQ_STORAGE_SLOW_REQUEST_SECONDS", 1e9),
+        patch.object(common, "TQ_STORAGE_LARGE_PAYLOAD_MB", 0.0),
+        patch.object(common, "TQ_STORAGE_SLOW_REQUEST_SECONDS", 1e9),
         caplog.at_level(logging.WARNING),
     ):
-        manager._log_if_heavy_put(time.perf_counter(), 512 * 2**20, 4, ["input_ids"], "unit_a")
+        common.log_heavy_operation("TQ_STORAGE_test", "put", 0.25, 512 * 2**20, "to unit_a samples=4")
 
     warning = next(r for r in caplog.records if "heavy put" in r.message)
     assert "serialized_mb=512.0" in warning.message
-    assert "10.0.0.7:5555" in warning.message
+    assert "to unit_a samples=4" in warning.message
+
+
+def test_log_heavy_operation_stays_silent_below_both_thresholds(caplog):
+    """Only requests past a threshold are worth a line; the normal path must not log."""
+    with (
+        patch.object(common, "TQ_STORAGE_LARGE_PAYLOAD_MB", 256.0),
+        patch.object(common, "TQ_STORAGE_SLOW_REQUEST_SECONDS", 5.0),
+        caplog.at_level(logging.WARNING),
+    ):
+        common.log_heavy_operation("TQ_STORAGE_test", "get", 0.01, 2**20, "samples=4")
+
+    assert not caplog.records
 
 
 @pytest.mark.asyncio
@@ -295,18 +304,3 @@ class _Writer:
 
     def close(self):
         pass
-
-
-def test_estimate_payload_bytes_handles_put_and_get_shapes():
-    """Both the batched put shape and the per-sample get shape must be measurable."""
-    batched = {"input_ids": torch.zeros(4, 8, dtype=torch.int64)}
-    per_sample = {"input_ids": [torch.zeros(8, dtype=torch.int64) for _ in range(4)]}
-
-    assert estimate_payload_bytes(batched) == 4 * 8 * 8
-    assert estimate_payload_bytes(per_sample) == 4 * 8 * 8
-
-
-def test_estimate_payload_bytes_degrades_to_zero_on_unmeasurable_input():
-    """Size estimation is diagnostic only and must never break the path it reports on."""
-    assert estimate_payload_bytes(object()) == 0
-    assert estimate_payload_bytes({"meta": "not a tensor"}) == 0

--- a/tests/test_storage_request_retry.py
+++ b/tests/test_storage_request_retry.py
@@ -86,6 +86,23 @@ async def test_retry_gives_up_after_configured_attempts():
 
 
 @pytest.mark.asyncio
+async def test_a_nonpositive_attempt_count_still_issues_one_request():
+    """Skipping the request would report success, and let put_data publish absent data."""
+    manager = _manager(unit_a=_server_info("unit_a", "10.0.0.7", 5555))
+    attempts = []
+
+    async def succeed():
+        attempts.append(1)
+        return "payload"
+
+    with patch.object(ssm, "TQ_SIMPLE_STORAGE_MAX_ATTEMPTS", 0):
+        result = await manager._request_with_retry("get", "unit_a", "samples=4", succeed)
+
+    assert result == "payload"
+    assert len(attempts) == 1
+
+
+@pytest.mark.asyncio
 async def test_errors_reported_by_the_unit_are_not_retried():
     """Only a missing answer is worth another connection; a real error must surface at once."""
     manager = _manager(unit_a=_server_info("unit_a", "10.0.0.7", 5555))

--- a/transfer_queue/storage/managers/simple_storage_manager.py
+++ b/transfer_queue/storage/managers/simple_storage_manager.py
@@ -387,9 +387,7 @@ class AsyncSimpleStorageManager(StorageManager):
         field_schema = extract_field_schema(data)
 
         routing = self._group_by_hash(metadata.global_indexes)
-        # Replaying a put is safe because it overwrites the same global indexes, but a retry also
-        # re-runs data_parser on the unit, and the public API does not require a parser to be free
-        # of side effects. So a parser-backed put is sent once and fails as it did before.
+        # Parser-backed puts are not replayed: the public API does not constrain parser side effects.
         max_attempts = 1 if data_parser is not None else None
         tasks = []
         for su_id, group in routing.items():

--- a/transfer_queue/storage/managers/simple_storage_manager.py
+++ b/transfer_queue/storage/managers/simple_storage_manager.py
@@ -31,12 +31,12 @@ from tensordict import NonTensorStack, TensorDict
 from transfer_queue.metadata import BatchMeta, extract_field_schema
 from transfer_queue.storage.managers.base import StorageManager, StorageManagerFactory
 from transfer_queue.storage.simple_storage import KEY_NOT_FOUND_MARKER, StorageKeyNotFoundError
-from transfer_queue.utils.common import estimate_payload_bytes
 from transfer_queue.utils.logging_utils import get_logger
 from transfer_queue.utils.zmq_utils import (
     ZMQMessage,
     ZMQRequestType,
     ZMQServerInfo,
+    frame_nbytes,
     with_zmq_socket,
 )
 
@@ -259,17 +259,17 @@ class AsyncSimpleStorageManager(StorageManager):
         for attempt in range(1, attempts_allowed + 1):
             try:
                 return await make_request()
-            except StorageUnitTimeout:
+            except StorageUnitTimeout as e:
                 if attempt < attempts_allowed:
                     logger.warning(
                         f"[{self.storage_manager_id}]: no answer from {target_storage_unit} at {endpoint} in "
                         f"{TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT}s, {operation} retry "
-                        f"{attempt + 1}/{attempts_allowed}. {request_context}"
+                        f"{attempt + 1}/{attempts_allowed}. {request_context} {e}"
                     )
                     continue
                 logger.error(
                     f"[{self.storage_manager_id}]: {operation} to {target_storage_unit} at {endpoint} failed "
-                    f"after {attempt}x{TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT}s. {request_context} "
+                    f"after {attempt}x{TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT}s. {request_context} {e} "
                     f"{await self._diagnose_storage_unit(target_storage_unit)}"
                 )
                 raise
@@ -396,8 +396,7 @@ class AsyncSimpleStorageManager(StorageManager):
                 self._request_with_retry(
                     "put",
                     su_id,
-                    f"samples={len(group.global_indexes)} fields={list(storage_data.keys())} "
-                    f"payload_mb={estimate_payload_bytes(storage_data) / 2**20:.1f}",
+                    f"samples={len(group.global_indexes)} fields={list(storage_data.keys())}",
                     partial(
                         self._put_to_single_storage_unit,
                         group.global_indexes,
@@ -450,9 +449,11 @@ class AsyncSimpleStorageManager(StorageManager):
             body={"global_indexes": global_indexes, "data": storage_data, "data_parser": data_parser},
         )
 
+        serialized_bytes = 0
         try:
-            data = request_msg.serialize()
-            await socket.send_multipart(data, copy=False)
+            frames = request_msg.serialize()
+            serialized_bytes = sum(frame_nbytes(frame) or 0 for frame in frames)
+            await socket.send_multipart(frames, copy=False)
             messages = await socket.recv_multipart(copy=False)
             response_msg = ZMQMessage.deserialize(messages)
 
@@ -464,7 +465,8 @@ class AsyncSimpleStorageManager(StorageManager):
         except zmq.error.Again as e:
             raise StorageUnitTimeout(
                 f"no answer in {TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT}s during put to storage unit "
-                f"{target_storage_unit} at {self._describe_storage_unit(target_storage_unit)}"
+                f"{target_storage_unit} at {self._describe_storage_unit(target_storage_unit)}; "
+                f"samples={len(global_indexes)} serialized_mb={serialized_bytes / 2**20:.1f}"
             ) from e
         except Exception as e:
             logger.error(

--- a/transfer_queue/storage/managers/simple_storage_manager.py
+++ b/transfer_queue/storage/managers/simple_storage_manager.py
@@ -61,6 +61,8 @@ class StorageUnitTimeout(RuntimeError):
     """A storage unit did not answer within the send/recv timeout.
 
     Distinct from an error the unit reported: only a missing answer is worth a new connection.
+    The message must name the unit, its endpoint and the timeout, because it is what the callers
+    of ``put_data`` and ``get_data`` see, and the retry logs rely on it instead of repeating them.
     """
 
 
@@ -257,7 +259,6 @@ class AsyncSimpleStorageManager(StorageManager):
             max_attempts: Attempts allowed. Defaults to ``TQ_SIMPLE_STORAGE_MAX_ATTEMPTS``; pass 1
                 for a request that must not be replayed.
         """
-        endpoint = self._describe_storage_unit(target_storage_unit)
         # Floored at one: a nonpositive count would skip the request and report success, which for
         # put would publish metadata for data that was never sent.
         attempts_allowed = max(1, TQ_SIMPLE_STORAGE_MAX_ATTEMPTS if max_attempts is None else max_attempts)
@@ -265,17 +266,17 @@ class AsyncSimpleStorageManager(StorageManager):
             try:
                 return await make_request()
             except StorageUnitTimeout as e:
+                # The exception already names the unit, its endpoint and the timeout, so these
+                # lines only add what it cannot know: which attempt this was, and the shape.
                 if attempt < attempts_allowed:
                     logger.warning(
-                        f"[{self.storage_manager_id}]: no answer from {target_storage_unit} at {endpoint} in "
-                        f"{TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT}s, {operation} retry "
-                        f"{attempt + 1}/{attempts_allowed}. {request_context} {e}"
+                        f"[{self.storage_manager_id}]: {operation} retry {attempt + 1}/{attempts_allowed} "
+                        f"on a new connection. {request_context} {e}"
                     )
                     continue
                 logger.error(
-                    f"[{self.storage_manager_id}]: {operation} to {target_storage_unit} at {endpoint} failed "
-                    f"after {attempt}x{TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT}s. {request_context} {e} "
-                    f"{await self._diagnose_storage_unit(target_storage_unit)}"
+                    f"[{self.storage_manager_id}]: {operation} failed after {attempt} attempts. "
+                    f"{request_context} {e} {await self._diagnose_storage_unit(target_storage_unit)}"
                 )
                 raise
 
@@ -482,7 +483,7 @@ class AsyncSimpleStorageManager(StorageManager):
             raise StorageUnitTimeout(
                 f"no answer in {TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT}s during put to storage unit "
                 f"{target_storage_unit} at {self._describe_storage_unit(target_storage_unit)}; "
-                f"samples={len(global_indexes)} serialized_mb={serialized_bytes / 2**20:.1f}"
+                f"serialized_mb={serialized_bytes / 2**20:.1f}"
             ) from e
         except Exception as e:
             logger.error(
@@ -632,7 +633,7 @@ class AsyncSimpleStorageManager(StorageManager):
                 raise error_type(f"Failed to get data from storage unit {target_storage_unit}: {message}")
         except zmq.error.Again as e:
             raise StorageUnitTimeout(
-                f"no answer in {TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT}s from storage unit "
+                f"no answer in {TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT}s during get from storage unit "
                 f"{target_storage_unit} at {self._describe_storage_unit(target_storage_unit)}"
             ) from e
         except StorageKeyNotFoundError:

--- a/transfer_queue/storage/managers/simple_storage_manager.py
+++ b/transfer_queue/storage/managers/simple_storage_manager.py
@@ -33,10 +33,9 @@ from transfer_queue.metadata import BatchMeta, extract_field_schema
 from transfer_queue.storage.managers.base import StorageManager, StorageManagerFactory
 from transfer_queue.storage.simple_storage import (
     KEY_NOT_FOUND_MARKER,
-    TQ_STORAGE_LARGE_PAYLOAD_MB,
-    TQ_STORAGE_SLOW_REQUEST_SECONDS,
     StorageKeyNotFoundError,
 )
+from transfer_queue.utils.common import log_heavy_operation
 from transfer_queue.utils.logging_utils import get_logger
 from transfer_queue.utils.zmq_utils import (
     ZMQMessage,
@@ -435,20 +434,6 @@ class AsyncSimpleStorageManager(StorageManager):
             field_schema,
         )
 
-    def _log_if_heavy_put(
-        self, started: float, serialized_bytes: int, num_samples: int, fields: Any, target_storage_unit: str
-    ) -> None:
-        """Log a put that was slow or unusually large on the wire; stay silent otherwise."""
-        elapsed = time.perf_counter() - started
-        payload_mb = serialized_bytes / 2**20
-        if elapsed < TQ_STORAGE_SLOW_REQUEST_SECONDS and payload_mb < TQ_STORAGE_LARGE_PAYLOAD_MB:
-            return
-        logger.warning(
-            f"[{self.storage_manager_id}]: heavy put to {target_storage_unit} "
-            f"at {self._describe_storage_unit(target_storage_unit)} samples={num_samples} "
-            f"serialized_mb={payload_mb:.1f} elapsed={elapsed:.2f}s fields={list(fields)}"
-        )
-
     @with_storage_unit_socket
     async def _put_to_single_storage_unit(
         self,
@@ -483,8 +468,15 @@ class AsyncSimpleStorageManager(StorageManager):
                     f"Failed to put data to storage unit {target_storage_unit}: "
                     f"{response_msg.body.get('message', 'Unknown error')}"
                 )
-            self._log_if_heavy_put(
-                started, serialized_bytes, len(global_indexes), storage_data.keys(), target_storage_unit
+            # This end serializes the put payload and waits out the round trip, so it holds both
+            # the true wire size and the end-to-end latency.
+            log_heavy_operation(
+                self.storage_manager_id,
+                "put",
+                time.perf_counter() - started,
+                serialized_bytes,
+                f"to {target_storage_unit} at {self._describe_storage_unit(target_storage_unit)} "
+                f"samples={len(global_indexes)} fields={list(storage_data.keys())}",
             )
         except zmq.error.Again as e:
             raise StorageUnitTimeout(

--- a/transfer_queue/storage/managers/simple_storage_manager.py
+++ b/transfer_queue/storage/managers/simple_storage_manager.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import os
+import time
 import warnings
 from collections import defaultdict
 from collections.abc import Mapping
@@ -30,7 +31,12 @@ from tensordict import NonTensorStack, TensorDict
 
 from transfer_queue.metadata import BatchMeta, extract_field_schema
 from transfer_queue.storage.managers.base import StorageManager, StorageManagerFactory
-from transfer_queue.storage.simple_storage import KEY_NOT_FOUND_MARKER, StorageKeyNotFoundError
+from transfer_queue.storage.simple_storage import (
+    KEY_NOT_FOUND_MARKER,
+    TQ_STORAGE_LARGE_PAYLOAD_MB,
+    TQ_STORAGE_SLOW_REQUEST_SECONDS,
+    StorageKeyNotFoundError,
+)
 from transfer_queue.utils.logging_utils import get_logger
 from transfer_queue.utils.zmq_utils import (
     ZMQMessage,
@@ -429,6 +435,20 @@ class AsyncSimpleStorageManager(StorageManager):
             field_schema,
         )
 
+    def _log_if_heavy_put(
+        self, started: float, serialized_bytes: int, num_samples: int, fields: Any, target_storage_unit: str
+    ) -> None:
+        """Log a put that was slow or unusually large on the wire; stay silent otherwise."""
+        elapsed = time.perf_counter() - started
+        payload_mb = serialized_bytes / 2**20
+        if elapsed < TQ_STORAGE_SLOW_REQUEST_SECONDS and payload_mb < TQ_STORAGE_LARGE_PAYLOAD_MB:
+            return
+        logger.warning(
+            f"[{self.storage_manager_id}]: heavy put to {target_storage_unit} "
+            f"at {self._describe_storage_unit(target_storage_unit)} samples={num_samples} "
+            f"serialized_mb={payload_mb:.1f} elapsed={elapsed:.2f}s fields={list(fields)}"
+        )
+
     @with_storage_unit_socket
     async def _put_to_single_storage_unit(
         self,
@@ -450,6 +470,7 @@ class AsyncSimpleStorageManager(StorageManager):
         )
 
         serialized_bytes = 0
+        started = time.perf_counter()
         try:
             frames = request_msg.serialize()
             serialized_bytes = sum(frame_nbytes(frame) or 0 for frame in frames)
@@ -462,6 +483,9 @@ class AsyncSimpleStorageManager(StorageManager):
                     f"Failed to put data to storage unit {target_storage_unit}: "
                     f"{response_msg.body.get('message', 'Unknown error')}"
                 )
+            self._log_if_heavy_put(
+                started, serialized_bytes, len(global_indexes), storage_data.keys(), target_storage_unit
+            )
         except zmq.error.Again as e:
             raise StorageUnitTimeout(
                 f"no answer in {TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT}s during put to storage unit "

--- a/transfer_queue/storage/managers/simple_storage_manager.py
+++ b/transfer_queue/storage/managers/simple_storage_manager.py
@@ -250,15 +250,18 @@ class AsyncSimpleStorageManager(StorageManager):
                 new socket per call, which ``with_storage_unit_socket`` does.
         """
         endpoint = self._describe_storage_unit(target_storage_unit)
-        for attempt in range(1, TQ_SIMPLE_STORAGE_MAX_ATTEMPTS + 1):
+        # Floored at one: a nonpositive count would skip the request and report success, which for
+        # put would publish metadata for data that was never sent.
+        attempts_allowed = max(1, TQ_SIMPLE_STORAGE_MAX_ATTEMPTS)
+        for attempt in range(1, attempts_allowed + 1):
             try:
                 return await make_request()
             except StorageUnitTimeout:
-                if attempt < TQ_SIMPLE_STORAGE_MAX_ATTEMPTS:
+                if attempt < attempts_allowed:
                     logger.warning(
                         f"[{self.storage_manager_id}]: no answer from {target_storage_unit} at {endpoint} in "
                         f"{TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT}s, {operation} retry "
-                        f"{attempt + 1}/{TQ_SIMPLE_STORAGE_MAX_ATTEMPTS}. {request_context}"
+                        f"{attempt + 1}/{attempts_allowed}. {request_context}"
                     )
                     continue
                 logger.error(

--- a/transfer_queue/storage/managers/simple_storage_manager.py
+++ b/transfer_queue/storage/managers/simple_storage_manager.py
@@ -239,6 +239,7 @@ class AsyncSimpleStorageManager(StorageManager):
         target_storage_unit: str,
         request_context: str,
         make_request: Callable[[], Any],
+        max_attempts: int | None = None,
     ):
         """Run one storage-unit request, retrying a missing answer on a fresh connection.
 
@@ -248,11 +249,13 @@ class AsyncSimpleStorageManager(StorageManager):
             request_context: Request shape, so both ends of a failure can be correlated.
             make_request: Zero-arg callable returning a coroutine for one attempt. Must build a
                 new socket per call, which ``with_storage_unit_socket`` does.
+            max_attempts: Attempts allowed. Defaults to ``TQ_SIMPLE_STORAGE_MAX_ATTEMPTS``; pass 1
+                for a request that must not be replayed.
         """
         endpoint = self._describe_storage_unit(target_storage_unit)
         # Floored at one: a nonpositive count would skip the request and report success, which for
         # put would publish metadata for data that was never sent.
-        attempts_allowed = max(1, TQ_SIMPLE_STORAGE_MAX_ATTEMPTS)
+        attempts_allowed = max(1, TQ_SIMPLE_STORAGE_MAX_ATTEMPTS if max_attempts is None else max_attempts)
         for attempt in range(1, attempts_allowed + 1):
             try:
                 return await make_request()
@@ -384,8 +387,10 @@ class AsyncSimpleStorageManager(StorageManager):
         field_schema = extract_field_schema(data)
 
         routing = self._group_by_hash(metadata.global_indexes)
-        # A retried put is replayed as-is: it overwrites the same global indexes, and re-runs
-        # data_parser on the unit, so a parser must be free of external side effects.
+        # Replaying a put is safe because it overwrites the same global indexes, but a retry also
+        # re-runs data_parser on the unit, and the public API does not require a parser to be free
+        # of side effects. So a parser-backed put is sent once and fails as it did before.
+        max_attempts = 1 if data_parser is not None else None
         tasks = []
         for su_id, group in routing.items():
             storage_data = {f: self._select_by_positions(data[f], group.batch_positions) for f in data.keys()}
@@ -402,6 +407,7 @@ class AsyncSimpleStorageManager(StorageManager):
                         target_storage_unit=su_id,
                         data_parser=data_parser,
                     ),
+                    max_attempts=max_attempts,
                 )
             )
 

--- a/transfer_queue/storage/managers/simple_storage_manager.py
+++ b/transfer_queue/storage/managers/simple_storage_manager.py
@@ -18,6 +18,7 @@ import os
 import warnings
 from collections import defaultdict
 from collections.abc import Mapping
+from functools import partial
 from operator import itemgetter
 from pathlib import Path
 from typing import Any, Callable, NamedTuple
@@ -30,6 +31,7 @@ from tensordict import NonTensorStack, TensorDict
 from transfer_queue.metadata import BatchMeta, extract_field_schema
 from transfer_queue.storage.managers.base import StorageManager, StorageManagerFactory
 from transfer_queue.storage.simple_storage import KEY_NOT_FOUND_MARKER, StorageKeyNotFoundError
+from transfer_queue.utils.common import estimate_payload_bytes
 from transfer_queue.utils.logging_utils import get_logger
 from transfer_queue.utils.zmq_utils import (
     ZMQMessage,
@@ -41,6 +43,21 @@ from transfer_queue.utils.zmq_utils import (
 logger = get_logger(__name__)
 
 TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT = int(os.environ.get("TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT", 200))  # seconds
+
+# Attempts per storage-unit request, including the first. Each one must use a new connection: a
+# DEALER silently queues messages for a peer it never reached, so no timeout can catch that.
+TQ_SIMPLE_STORAGE_MAX_ATTEMPTS = int(os.environ.get("TQ_SIMPLE_STORAGE_MAX_ATTEMPTS", 3))
+
+# Timeout for the post-failure probe, which only has to answer whether the unit still serves.
+TQ_SIMPLE_STORAGE_PROBE_TIMEOUT = int(os.environ.get("TQ_SIMPLE_STORAGE_PROBE_TIMEOUT", 10))
+
+
+class StorageUnitTimeout(RuntimeError):
+    """A storage unit did not answer within the send/recv timeout.
+
+    Distinct from an error the unit reported: only a missing answer is worth a new connection.
+    """
+
 
 _SU_SUBDIR = "simple_storage"
 _SU_INFO_FILE = "storage_unit_info.json"
@@ -55,6 +72,16 @@ with_storage_unit_socket = with_zmq_socket(
     get_context=lambda self: self.zmq_context,
     resolve_target=lambda args, kwargs: kwargs.get("target_storage_unit"),
     timeout=TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT,
+)
+
+# Same endpoint as above but with the short diagnostic timeout, used only after a failure.
+with_storage_unit_probe_socket = with_zmq_socket(
+    "put_get_socket",
+    get_identity=lambda self: f"{self.storage_manager_id}_probe",
+    get_peer=lambda self, target: self.storage_unit_infos[target],
+    get_context=lambda self: self.zmq_context,
+    resolve_target=lambda args, kwargs: kwargs.get("target_storage_unit"),
+    timeout=TQ_SIMPLE_STORAGE_PROBE_TIMEOUT,
 )
 
 
@@ -143,6 +170,103 @@ class AsyncSimpleStorageManager(StorageManager):
             gi_lists[key].append(global_idx)
             pos_lists[key].append(pos)
         return {key: RoutingGroup(gi_lists[key], pos_lists[key]) for key in gi_lists}
+
+    def _describe_storage_unit(self, storage_unit_id: str) -> str:
+        """Return ``ip:port`` for a storage unit, for use in diagnostics.
+
+        The unit id is a random uuid4 fragment that carries no location, so a bare id in an
+        error message cannot be traced back to a node. Never raises: it is only ever called
+        while reporting another failure, and must not mask it.
+        """
+        info = self.storage_unit_infos.get(storage_unit_id)
+        if info is None:
+            return "endpoint unknown (unit not registered with this manager)"
+        return f"{info.ip}:{info.ports.get('put_get_socket')}"
+
+    @with_storage_unit_probe_socket
+    async def _probe_storage_unit(self, target_storage_unit: str, socket: zmq.Socket = None) -> dict[str, Any]:
+        """Ask a storage unit for its own counters over a brand-new socket.
+
+        Served by the same worker thread as put and get, so an answer proves the unit is serving.
+        """
+        request_msg = ZMQMessage.create(
+            request_type=ZMQRequestType.GET_METRICS,  # type: ignore[arg-type]
+            sender_id=f"{self.storage_manager_id}_probe",
+            receiver_id=target_storage_unit,
+            body={},
+        )
+        await socket.send_multipart(request_msg.serialize())
+        messages = await socket.recv_multipart(copy=False)
+        response_msg = ZMQMessage.deserialize(messages)
+        if response_msg.request_type != ZMQRequestType.METRICS_RESPONSE:
+            raise RuntimeError(f"unexpected probe response type {response_msg.request_type}")
+        return response_msg.body
+
+    async def _diagnose_storage_unit(self, target_storage_unit: str) -> str:
+        """Classify a timeout as a lost request, a stuck unit, or an unreachable node.
+
+        Returns one log line and never raises: it runs while another failure is being reported.
+        """
+        info = self.storage_unit_infos.get(target_storage_unit)
+        if info is None:
+            return "verdict=unknown(unit_not_registered)"
+
+        try:
+            _, writer = await asyncio.wait_for(
+                asyncio.open_connection(info.ip, info.ports.get("put_get_socket")), timeout=5
+            )
+            writer.close()
+            tcp = "tcp=up"
+        except Exception as e:
+            tcp = f"tcp=down({type(e).__name__})"
+
+        try:
+            body = await self._probe_storage_unit(target_storage_unit=target_storage_unit)
+            op_counts = {op: stats.get("request_count") for op, stats in (body.get("op_stats") or {}).items()}
+            return (
+                f"{tcp} verdict=request_lost_in_flight (unit answered a fresh probe: "
+                f"ops={op_counts} active_keys={body.get('active_keys')} "
+                f"rss_gb={body.get('process_rss_bytes', 0) / 2**30:.2f})"
+            )
+        except zmq.error.Again:
+            return f"{tcp} verdict=unit_not_serving (no probe answer in {TQ_SIMPLE_STORAGE_PROBE_TIMEOUT}s)"
+        except Exception as e:
+            return f"{tcp} verdict=unknown (probe failed: {type(e).__name__}: {e})"
+
+    async def _request_with_retry(
+        self,
+        operation: str,
+        target_storage_unit: str,
+        request_context: str,
+        make_request: Callable[[], Any],
+    ):
+        """Run one storage-unit request, retrying a missing answer on a fresh connection.
+
+        Args:
+            operation: Operation name for logs, e.g. ``get`` or ``put``.
+            target_storage_unit: Unit this request is routed to.
+            request_context: Request shape, so both ends of a failure can be correlated.
+            make_request: Zero-arg callable returning a coroutine for one attempt. Must build a
+                new socket per call, which ``with_storage_unit_socket`` does.
+        """
+        endpoint = self._describe_storage_unit(target_storage_unit)
+        for attempt in range(1, TQ_SIMPLE_STORAGE_MAX_ATTEMPTS + 1):
+            try:
+                return await make_request()
+            except StorageUnitTimeout:
+                if attempt < TQ_SIMPLE_STORAGE_MAX_ATTEMPTS:
+                    logger.warning(
+                        f"[{self.storage_manager_id}]: no answer from {target_storage_unit} at {endpoint} in "
+                        f"{TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT}s, {operation} retry "
+                        f"{attempt + 1}/{TQ_SIMPLE_STORAGE_MAX_ATTEMPTS}. {request_context}"
+                    )
+                    continue
+                logger.error(
+                    f"[{self.storage_manager_id}]: {operation} to {target_storage_unit} at {endpoint} failed "
+                    f"after {attempt}x{TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT}s. {request_context} "
+                    f"{await self._diagnose_storage_unit(target_storage_unit)}"
+                )
+                raise
 
     @staticmethod
     def _select_by_positions(field_data, positions: list[int]):
@@ -257,24 +381,37 @@ class AsyncSimpleStorageManager(StorageManager):
         field_schema = extract_field_schema(data)
 
         routing = self._group_by_hash(metadata.global_indexes)
-        tasks = [
-            self._put_to_single_storage_unit(
-                group.global_indexes,
-                {f: self._select_by_positions(data[f], group.batch_positions) for f in data.keys()},
-                target_storage_unit=su_id,
-                data_parser=data_parser,
+        # A retried put is replayed as-is: it overwrites the same global indexes, and re-runs
+        # data_parser on the unit, so a parser must be free of external side effects.
+        tasks = []
+        for su_id, group in routing.items():
+            storage_data = {f: self._select_by_positions(data[f], group.batch_positions) for f in data.keys()}
+            tasks.append(
+                self._request_with_retry(
+                    "put",
+                    su_id,
+                    f"samples={len(group.global_indexes)} fields={list(storage_data.keys())} "
+                    f"payload_mb={estimate_payload_bytes(storage_data) / 2**20:.1f}",
+                    partial(
+                        self._put_to_single_storage_unit,
+                        group.global_indexes,
+                        storage_data,
+                        target_storage_unit=su_id,
+                        data_parser=data_parser,
+                    ),
+                )
             )
-            for su_id, group in routing.items()
-        ]
 
         try:
             await asyncio.gather(*tasks)
         except Exception as e:
+            # The offending unit is named in the error itself; the full routing list can run to
+            # hundreds of ids, which buries it.
             logger.error(
                 f"[{self.storage_manager_id}]: put_data failed. "
                 f"partition_id={metadata.partition_ids[0]}, "
                 f"num_samples={metadata.size}, "
-                f"storage_units={list(routing.keys())}, "
+                f"num_storage_units={len(routing)}, "
                 f"error={type(e).__name__}: {e}"
             )
             raise
@@ -318,14 +455,9 @@ class AsyncSimpleStorageManager(StorageManager):
                     f"{response_msg.body.get('message', 'Unknown error')}"
                 )
         except zmq.error.Again as e:
-            timeout_sec = TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT
-            logger.error(
-                f"[{self.storage_manager_id}]: ZMQ recv timeout ({timeout_sec}s) "
-                f"during put to storage unit {target_storage_unit}. "
-                f"The storage unit may be overloaded or crashed."
-            )
-            raise RuntimeError(
-                f"ZMQ recv timeout ({timeout_sec}s) during put to storage unit {target_storage_unit}"
+            raise StorageUnitTimeout(
+                f"no answer in {TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT}s during put to storage unit "
+                f"{target_storage_unit} at {self._describe_storage_unit(target_storage_unit)}"
             ) from e
         except Exception as e:
             logger.error(
@@ -405,7 +537,17 @@ class AsyncSimpleStorageManager(StorageManager):
         routing = self._group_by_hash(metadata.global_indexes)
 
         tasks = [
-            self._get_from_single_storage_unit(group.global_indexes, metadata.field_names, target_storage_unit=su_id)
+            self._request_with_retry(
+                "get",
+                su_id,
+                f"samples={len(group.global_indexes)} fields={list(metadata.field_names)}",
+                partial(
+                    self._get_from_single_storage_unit,
+                    group.global_indexes,
+                    metadata.field_names,
+                    target_storage_unit=su_id,
+                ),
+            )
             for su_id, group in routing.items()
         ]
         try:
@@ -464,13 +606,10 @@ class AsyncSimpleStorageManager(StorageManager):
                 error_type = StorageKeyNotFoundError if KEY_NOT_FOUND_MARKER in message else RuntimeError
                 raise error_type(f"Failed to get data from storage unit {target_storage_unit}: {message}")
         except zmq.error.Again as e:
-            timeout_sec = TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT
-            logger.error(
-                f"[{self.storage_manager_id}]: ZMQ recv timeout ({timeout_sec}s) "
-                f"from storage unit {target_storage_unit}. "
-                f"The storage unit may be overloaded or crashed."
-            )
-            raise RuntimeError(f"ZMQ recv timeout ({timeout_sec}s) from storage unit {target_storage_unit}") from e
+            raise StorageUnitTimeout(
+                f"no answer in {TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT}s from storage unit "
+                f"{target_storage_unit} at {self._describe_storage_unit(target_storage_unit)}"
+            ) from e
         except StorageKeyNotFoundError:
             # Already logged at debug by the storage unit; propagate for the caller to classify.
             raise

--- a/transfer_queue/storage/simple_storage.py
+++ b/transfer_queue/storage/simple_storage.py
@@ -400,7 +400,10 @@ class SimpleStorageUnit:
         worker_socket.close(linger=0)
 
     def _log_if_heavy(self, operation: str, started: float, field_data: Any, num_samples: int, fields: Any) -> None:
-        """Log a request that was slow or unusually large, and stay silent otherwise."""
+        """Log a get that was slow or unusually large on this unit; stay silent otherwise.
+
+        Put heavy logging lives on the manager, which sees the wire size and end-to-end RTT.
+        """
         elapsed = time.perf_counter() - started
         payload_mb = estimate_payload_bytes(field_data) / 2**20
         if elapsed < TQ_STORAGE_SLOW_REQUEST_SECONDS and payload_mb < TQ_STORAGE_LARGE_PAYLOAD_MB:
@@ -425,7 +428,6 @@ class SimpleStorageUnit:
             field_data = data_parts.body["data"]  # field_data should be a dict.
             data_parser = data_parts.body.get("data_parser", None)
 
-            started = time.perf_counter()
             with limit_pytorch_auto_parallel_threads(
                 target_num_threads=TQ_NUM_THREADS, info=f"[{self.storage_unit_id}] _handle_put"
             ):
@@ -472,8 +474,6 @@ class SimpleStorageUnit:
                                 f"expected {orig_len}, got {new_len}"
                             )
                 self.storage_data.put_data(field_data, global_indexes)
-
-            self._log_if_heavy("PUT_DATA", started, field_data, len(global_indexes), field_data.keys())
 
             # After put operation finish, send a message to the client
             response_msg = ZMQMessage.create(

--- a/transfer_queue/storage/simple_storage.py
+++ b/transfer_queue/storage/simple_storage.py
@@ -25,7 +25,7 @@ import psutil
 import ray
 import zmq
 
-from transfer_queue.utils.common import limit_pytorch_auto_parallel_threads
+from transfer_queue.utils.common import estimate_payload_bytes, limit_pytorch_auto_parallel_threads
 from transfer_queue.utils.enum_utils import Role
 from transfer_queue.utils.logging_utils import get_logger
 from transfer_queue.utils.perf_utils import IntervalPerfMonitor
@@ -47,6 +47,11 @@ logger = get_logger(__name__)
 
 TQ_STORAGE_POLLER_TIMEOUT = int(os.environ.get("TQ_STORAGE_POLLER_TIMEOUT", 5))  # in seconds
 TQ_NUM_THREADS = int(os.environ.get("TQ_NUM_THREADS", 8))
+
+# Thresholds above which a single request earns a log line. Both sit far above the normal range
+# of single-digit milliseconds, so tripping either one is itself the finding.
+TQ_STORAGE_SLOW_REQUEST_SECONDS = float(os.environ.get("TQ_STORAGE_SLOW_REQUEST_SECONDS", 5.0))
+TQ_STORAGE_LARGE_PAYLOAD_MB = float(os.environ.get("TQ_STORAGE_LARGE_PAYLOAD_MB", 256))
 
 # Marks a GET_ERROR reply as "the key is gone" so the caller can tell it apart from a real fault.
 KEY_NOT_FOUND_MARKER = "TQKeyNotFound"
@@ -394,6 +399,17 @@ class SimpleStorageUnit:
         poller.unregister(worker_socket)
         worker_socket.close(linger=0)
 
+    def _log_if_heavy(self, operation: str, started: float, field_data: Any, num_samples: int, fields: Any) -> None:
+        """Log a request that was slow or unusually large, and stay silent otherwise."""
+        elapsed = time.perf_counter() - started
+        payload_mb = estimate_payload_bytes(field_data) / 2**20
+        if elapsed < TQ_STORAGE_SLOW_REQUEST_SECONDS and payload_mb < TQ_STORAGE_LARGE_PAYLOAD_MB:
+            return
+        logger.warning(
+            f"[{self.storage_unit_id}]: heavy {operation} samples={num_samples} "
+            f"payload_mb={payload_mb:.1f} elapsed={elapsed:.2f}s fields={list(fields)}"
+        )
+
     def _handle_put(self, data_parts: ZMQMessage) -> ZMQMessage:
         """
         Handle put request, add or update data into storage unit.
@@ -409,6 +425,7 @@ class SimpleStorageUnit:
             field_data = data_parts.body["data"]  # field_data should be a dict.
             data_parser = data_parts.body.get("data_parser", None)
 
+            started = time.perf_counter()
             with limit_pytorch_auto_parallel_threads(
                 target_num_threads=TQ_NUM_THREADS, info=f"[{self.storage_unit_id}] _handle_put"
             ):
@@ -456,6 +473,8 @@ class SimpleStorageUnit:
                             )
                 self.storage_data.put_data(field_data, global_indexes)
 
+            self._log_if_heavy("PUT_DATA", started, field_data, len(global_indexes), field_data.keys())
+
             # After put operation finish, send a message to the client
             response_msg = ZMQMessage.create(
                 request_type=ZMQRequestType.PUT_DATA_RESPONSE,  # type: ignore[arg-type]
@@ -488,10 +507,13 @@ class SimpleStorageUnit:
             fields = data_parts.body["fields"]
             global_indexes = data_parts.body["global_indexes"]
 
+            started = time.perf_counter()
             with limit_pytorch_auto_parallel_threads(
                 target_num_threads=TQ_NUM_THREADS, info=f"[{self.storage_unit_id}] _handle_get"
             ):
                 result_data = self.storage_data.get_data(fields, global_indexes)
+
+            self._log_if_heavy("GET_DATA", started, result_data, len(global_indexes), fields)
 
             response_msg = ZMQMessage.create(
                 request_type=ZMQRequestType.GET_DATA_RESPONSE,  # type: ignore[arg-type]

--- a/transfer_queue/storage/simple_storage.py
+++ b/transfer_queue/storage/simple_storage.py
@@ -25,7 +25,7 @@ import psutil
 import ray
 import zmq
 
-from transfer_queue.utils.common import estimate_payload_bytes, limit_pytorch_auto_parallel_threads
+from transfer_queue.utils.common import limit_pytorch_auto_parallel_threads, log_heavy_operation
 from transfer_queue.utils.enum_utils import Role
 from transfer_queue.utils.logging_utils import get_logger
 from transfer_queue.utils.perf_utils import IntervalPerfMonitor
@@ -36,6 +36,7 @@ from transfer_queue.utils.zmq_utils import (
     ZMQServerInfo,
     create_zmq_socket,
     format_zmq_address,
+    frame_nbytes,
     get_free_port,
     get_node_ip_address,
 )
@@ -47,11 +48,6 @@ logger = get_logger(__name__)
 
 TQ_STORAGE_POLLER_TIMEOUT = int(os.environ.get("TQ_STORAGE_POLLER_TIMEOUT", 5))  # in seconds
 TQ_NUM_THREADS = int(os.environ.get("TQ_NUM_THREADS", 8))
-
-# Thresholds above which a single request earns a log line. Both sit far above the normal range
-# of single-digit milliseconds, so tripping either one is itself the finding.
-TQ_STORAGE_SLOW_REQUEST_SECONDS = float(os.environ.get("TQ_STORAGE_SLOW_REQUEST_SECONDS", 5.0))
-TQ_STORAGE_LARGE_PAYLOAD_MB = float(os.environ.get("TQ_STORAGE_LARGE_PAYLOAD_MB", 256))
 
 # Marks a GET_ERROR reply as "the key is gone" so the caller can tell it apart from a real fault.
 KEY_NOT_FOUND_MARKER = "TQKeyNotFound"
@@ -349,6 +345,7 @@ class SimpleStorageUnit:
                     worker_socket.send_multipart([identity] + error_msg.serialize(), copy=False)
                     continue
                 operation = request_msg.request_type
+                started = time.perf_counter()
 
                 try:
                     logger.debug(f"[{self.storage_unit_id}]: worker received operation: {operation}")
@@ -393,25 +390,22 @@ class SimpleStorageUnit:
                     )
 
                 # Send response back with identity for routing
-                worker_socket.send_multipart([identity] + response_msg.serialize(), copy=False)
+                response_frames = response_msg.serialize()
+                if operation == ZMQRequestType.GET_DATA:  # type: ignore[arg-type]
+                    # This end serializes the get response, so its frames give the true wire size.
+                    log_heavy_operation(
+                        self.storage_unit_id,
+                        "get",
+                        time.perf_counter() - started,
+                        sum(frame_nbytes(frame) or 0 for frame in response_frames),
+                        f"samples={len(request_msg.body.get('global_indexes', []))} "
+                        f"fields={list(request_msg.body.get('fields', []))}",
+                    )
+                worker_socket.send_multipart([identity] + response_frames, copy=False)
 
         logger.info(f"[{self.storage_unit_id}]: worker stopped.")
         poller.unregister(worker_socket)
         worker_socket.close(linger=0)
-
-    def _log_if_heavy(self, operation: str, started: float, field_data: Any, num_samples: int, fields: Any) -> None:
-        """Log a get that was slow or unusually large on this unit; stay silent otherwise.
-
-        Put heavy logging lives on the manager, which sees the wire size and end-to-end RTT.
-        """
-        elapsed = time.perf_counter() - started
-        payload_mb = estimate_payload_bytes(field_data) / 2**20
-        if elapsed < TQ_STORAGE_SLOW_REQUEST_SECONDS and payload_mb < TQ_STORAGE_LARGE_PAYLOAD_MB:
-            return
-        logger.warning(
-            f"[{self.storage_unit_id}]: heavy {operation} samples={num_samples} "
-            f"payload_mb={payload_mb:.1f} elapsed={elapsed:.2f}s fields={list(fields)}"
-        )
 
     def _handle_put(self, data_parts: ZMQMessage) -> ZMQMessage:
         """
@@ -507,13 +501,10 @@ class SimpleStorageUnit:
             fields = data_parts.body["fields"]
             global_indexes = data_parts.body["global_indexes"]
 
-            started = time.perf_counter()
             with limit_pytorch_auto_parallel_threads(
                 target_num_threads=TQ_NUM_THREADS, info=f"[{self.storage_unit_id}] _handle_get"
             ):
                 result_data = self.storage_data.get_data(fields, global_indexes)
-
-            self._log_if_heavy("GET_DATA", started, result_data, len(global_indexes), fields)
 
             response_msg = ZMQMessage.create(
                 request_type=ZMQRequestType.GET_DATA_RESPONSE,  # type: ignore[arg-type]

--- a/transfer_queue/utils/common.py
+++ b/transfer_queue/utils/common.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 
 import os
+from collections.abc import Mapping
 from contextlib import contextmanager
+from typing import Any
 
 import psutil
 import ray
@@ -133,3 +135,22 @@ def get_env_bool(env_key: str, default: bool = False) -> bool:
 
     true_values = {"true", "1", "yes", "y", "on"}
     return env_value_lower in true_values
+
+
+def estimate_payload_bytes(field_data: Any) -> int:
+    """Best-effort size of a request payload in bytes; 0 when it cannot be measured.
+
+    Walks two levels: covers both put's ``field -> value`` and get's ``field -> per-sample list``.
+    """
+    total = 0
+    try:
+        values = field_data.values() if isinstance(field_data, Mapping) else field_data
+        for value in values:
+            items = value if isinstance(value, list | tuple) else [value]
+            for item in items:
+                nbytes = getattr(item, "nbytes", None)
+                if isinstance(nbytes, int):
+                    total += nbytes
+    except Exception:
+        return 0
+    return total

--- a/transfer_queue/utils/common.py
+++ b/transfer_queue/utils/common.py
@@ -14,9 +14,7 @@
 # limitations under the License.
 
 import os
-from collections.abc import Mapping
 from contextlib import contextmanager
-from typing import Any
 
 import psutil
 import ray
@@ -137,20 +135,25 @@ def get_env_bool(env_key: str, default: bool = False) -> bool:
     return env_value_lower in true_values
 
 
-def estimate_payload_bytes(field_data: Any) -> int:
-    """Best-effort size of a request payload in bytes; 0 when it cannot be measured.
+# Thresholds above which a single request earns a log line. Both sit far above the normal range
+# of single-digit milliseconds, so tripping either one is itself the finding.
+TQ_STORAGE_SLOW_REQUEST_SECONDS = float(os.environ.get("TQ_STORAGE_SLOW_REQUEST_SECONDS", 5.0))
+TQ_STORAGE_LARGE_PAYLOAD_MB = float(os.environ.get("TQ_STORAGE_LARGE_PAYLOAD_MB", 256))
 
-    Walks two levels: covers both put's ``field -> value`` and get's ``field -> per-sample list``.
+
+def log_heavy_operation(component_id: str, operation: str, elapsed: float, payload_bytes: int, detail: str) -> None:
+    """Warn about one slow or unusually large request; stay silent otherwise.
+
+    Args:
+        component_id: Storage manager or storage unit reporting the request.
+        operation: Operation name, e.g. ``put`` or ``get``.
+        elapsed: Wall time spent on the request, in seconds.
+        payload_bytes: Serialized size of the payload on the wire.
+        detail: Request shape, appended to the message verbatim.
     """
-    total = 0
-    try:
-        values = field_data.values() if isinstance(field_data, Mapping) else field_data
-        for value in values:
-            items = value if isinstance(value, list | tuple) else [value]
-            for item in items:
-                nbytes = getattr(item, "nbytes", None)
-                if isinstance(nbytes, int):
-                    total += nbytes
-    except Exception:
-        return 0
-    return total
+    payload_mb = payload_bytes / 2**20
+    if elapsed < TQ_STORAGE_SLOW_REQUEST_SECONDS and payload_mb < TQ_STORAGE_LARGE_PAYLOAD_MB:
+        return
+    logger.warning(
+        f"[{component_id}]: heavy {operation} {detail} serialized_mb={payload_mb:.1f} elapsed={elapsed:.2f}s"
+    )


### PR DESCRIPTION
## Problem

A storage unit stops answering and every client routed to it fails when its own recv timeout
expires. Raising the timeout (400s to 1800s in our deployment) changed nothing.

Evidence from one such failure: the unit's node was alive and serving other traffic throughout, a
TCP connect to its `put_get_socket` succeeded, and the unit's own counters showed it fully healthy
(1025 GET_DATA served, 9.6ms p99, 1.33GB RSS). It had served exactly one GET_DATA fewer than its
cohort. So the unit never saw the request that timed out; it was lost between the two ends, not
queued behind slow work. #168 protected the worker thread from dying, which is a different cause of
the same symptom; here the thread was intact.

That loss is invisible by construction. ZMQ connect is asynchronous and SNDHWM is 0, so a DEALER
accepts `send()` into an unbounded local queue for a peer it has not reached yet. The caller only
learns anything when its own RCVTIMEO expires, which is why no timeout value can distinguish a lost
request from a slow one. Lowering SNDHWM would not help either, it only trades silent queuing for
silent dropping.

## Fix

1. **Retry on a new connection.** Up to `TQ_SIMPLE_STORAGE_MAX_ATTEMPTS` (default 3, floored at 1).
   A fresh socket and TCP connection is the part that matters. Only a missing answer is retried:
   `zmq.error.Again` now raises `StorageUnitTimeout`, while an error the unit reported surfaces on
   the first attempt. Replaying is safe where it is used: get is read-only and put overwrites the
   same global indexes. A put carrying a `data_parser` is the exception and is sent once, because a
   retry would re-run the parser on the unit and the public API does not constrain its side
   effects.
2. **Self-diagnosing residual failure.** After the last attempt, ask the unit for its own counters
   over a fresh socket with a short timeout. That probe is served by the same worker thread as put
   and get, so an answer proves the request was lost in flight and silence means the unit itself
   stopped. The failure log carries that verdict plus tcp reachability, the unit's op counts and RSS,
   and the wire size of the request that failed (measured from the serialized ZMQ frames on put).
3. **Log volume unchanged in the steady state.** A recovered request logs one line and skips the
   diagnosis entirely. Heavy requests are logged only above `TQ_STORAGE_SLOW_REQUEST_SECONDS` (5s)
   or `TQ_STORAGE_LARGE_PAYLOAD_MB` (256MB), via shared `log_heavy_operation`: puts on the manager
   (serialized request frames + end-to-end RTT), gets on the unit (serialized response frames +
   local handling time). No tensor-`nbytes` estimate remains.

## Tests

`tests/test_storage_request_retry.py`: 14 passed. Covers recovery on retry, the bounded attempt
count, that a nonpositive count still issues one request, that errors reported by the unit are not
retried, that a parser-backed put is not replayed while the ordinary put still is, that retry logs
carry wire-size detail from the failed attempt, shared heavy-request logging thresholds, and each
diagnosis verdict.

Full non-e2e run: 623 passed, 10 skipped, plus `python -m compileall -q transfer_queue tutorial tests`.
`test_yuanrong_storage_client_e2e.py` is excluded locally, it needs the optional
`openyuanrong-datasystem` dependency.